### PR TITLE
Migrate BaseRedisType actions to mark_actions v2

### DIFF
--- a/.github/workflows/speed.yml
+++ b/.github/workflows/speed.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
   workflow_dispatch:
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "CodSpeed": {
+      "type": "http",
+      "url": "https://mcp.codspeed.io/mcp"
+    }
+  }
+}

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -1,12 +1,22 @@
+import enum
 from typing import Any, ClassVar
 
 import pytest
 
 from rapyer import AtomicRedisModel
-from rapyer.actions import ActionGroup
-from tests.build_helpers import recursive_build_redis_model
 
-BENCHMARK_TTL_SECONDS = 3600
+
+class TTLMode(enum.Enum):
+    """Which model variant a benchmark iteration is exercising.
+
+    Each test class declares a ``models`` mapping from this enum to the model
+    class it should construct in setup. The TTL variant is a separate, pristine
+    subclass with TTL configured at class-definition time — no Meta mutation,
+    no install/uninstall cycles between benchmarks.
+    """
+
+    NO_TTL = "no_ttl"
+    TTL = "ttl"
 
 
 class AsyncBenchmarkTest:
@@ -14,15 +24,20 @@ class AsyncBenchmarkTest:
     rounds = 20
     expected = None
 
-    async def setup(self) -> Any:
+    # Subclasses override. ``TTLMode.NO_TTL`` is required (used by
+    # ``test_benchmark``); ``TTLMode.TTL`` is required by subclasses that also
+    # run ``test_benchmark_with_ttl``.
+    models: ClassVar[dict[TTLMode, type[AtomicRedisModel]]] = {}
+
+    async def setup(self, mode: TTLMode) -> Any:
         return None
 
     async def action(self, *args, **kwargs) -> Any:
         raise NotImplementedError()
 
-    def _run(self, benchmark, event_loop):
+    def _run(self, benchmark, event_loop, mode: TTLMode):
         def sync_setup():
-            result = event_loop.run_until_complete(self.setup())
+            result = event_loop.run_until_complete(self.setup(mode))
             if result is None:
                 return (), {}
             return (result,), {}
@@ -36,25 +51,9 @@ class AsyncBenchmarkTest:
             assert result == self.expected
 
     def test_benchmark(self, benchmark, event_loop):
-        self._run(benchmark, event_loop)
+        self._run(benchmark, event_loop, TTLMode.NO_TTL)
 
 
 class AsyncBenchmarkTestWithTTL(AsyncBenchmarkTest):
-    models_for_ttl: ClassVar[tuple[type[AtomicRedisModel], ...]] = ()
-
     def test_benchmark_with_ttl(self, benchmark, event_loop):
-        original = [
-            (cls, cls.Meta.ttl, cls.Meta.refresh_ttl) for cls in self.models_for_ttl
-        ]
-        for cls in self.models_for_ttl:
-            cls.Meta.ttl = BENCHMARK_TTL_SECONDS
-            cls.Meta.refresh_ttl = ActionGroup.all(for_ttl=True)
-            # Recreate the model to ensure ttl updates actions
-            recursive_build_redis_model(cls)
-        try:
-            self._run(benchmark, event_loop)
-        finally:
-            for cls, ttl, original_refresh in original:
-                cls.Meta.ttl = ttl
-                cls.Meta.refresh_ttl = original_refresh
-                recursive_build_redis_model(cls)
+        self._run(benchmark, event_loop, TTLMode.TTL)

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -4,6 +4,7 @@ import pytest
 
 from rapyer import AtomicRedisModel
 from rapyer.actions import ActionGroup
+from tests.build_helpers import recursive_build_redis_model
 
 BENCHMARK_TTL_SECONDS = 3600
 
@@ -49,11 +50,11 @@ class AsyncBenchmarkTestWithTTL(AsyncBenchmarkTest):
             cls.Meta.ttl = BENCHMARK_TTL_SECONDS
             cls.Meta.refresh_ttl = ActionGroup.all(for_ttl=True)
             # Recreate the model to ensure ttl updates actions
-            cls.build_redis_model()
+            recursive_build_redis_model(cls)
         try:
             self._run(benchmark, event_loop)
         finally:
             for cls, ttl, original_refresh in original:
                 cls.Meta.ttl = ttl
                 cls.Meta.refresh_ttl = original_refresh
-                cls.build_redis_model()
+                recursive_build_redis_model(cls)

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -1,0 +1,78 @@
+from typing import ClassVar
+
+from rapyer.actions import ActionGroup
+from rapyer.config import RedisConfig
+from tests.models.collection_types import (
+    ComprehensiveTestModel,
+    SimpleListModel,
+    StrDictModel,
+)
+from tests.models.index_types import IndexTestModel
+from tests.models.redis_types import DirectRedisIntModel
+from tests.models.simple_types import FloatModel, IntModel, StrModel
+from tests.models.special_types import PriorityQueueModel
+
+BENCHMARK_TTL_SECONDS = 3600
+
+
+class StrDictModelWithTTL(StrDictModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class SimpleListModelWithTTL(SimpleListModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class ComprehensiveTestModelWithTTL(ComprehensiveTestModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class StrModelWithTTL(StrModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class IntModelWithTTL(IntModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class FloatModelWithTTL(FloatModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class IndexTestModelWithTTL(IndexTestModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class DirectRedisIntModelWithTTL(DirectRedisIntModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )
+
+
+class PriorityQueueModelWithTTL(PriorityQueueModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=BENCHMARK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.all(for_ttl=True),
+    )

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -2,11 +2,7 @@ from typing import ClassVar
 
 from rapyer.actions import ActionGroup
 from rapyer.config import RedisConfig
-from tests.models.collection_types import (
-    ComprehensiveTestModel,
-    SimpleListModel,
-    StrDictModel,
-)
+from tests.models.collection_types import SimpleListModel, StrDictModel
 from tests.models.index_types import IndexTestModel
 from tests.models.redis_types import DirectRedisIntModel
 from tests.models.simple_types import FloatModel, IntModel, StrModel
@@ -29,13 +25,6 @@ class SimpleListModelWithTTL(SimpleListModel):
     )
 
 
-class ComprehensiveTestModelWithTTL(ComprehensiveTestModel):
-    Meta: ClassVar[RedisConfig] = RedisConfig(
-        ttl=BENCHMARK_TTL_SECONDS,
-        refresh_ttl=ActionGroup.all(for_ttl=True),
-    )
-
-
 class StrModelWithTTL(StrModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(
         ttl=BENCHMARK_TTL_SECONDS,
@@ -50,11 +39,8 @@ class IntModelWithTTL(IntModel):
     )
 
 
-class FloatModelWithTTL(FloatModel):
-    Meta: ClassVar[RedisConfig] = RedisConfig(
-        ttl=BENCHMARK_TTL_SECONDS,
-        refresh_ttl=ActionGroup.all(for_ttl=True),
-    )
+class FloatModelNoTTL(FloatModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=None)
 
 
 class IndexTestModelWithTTL(IndexTestModel):
@@ -71,8 +57,5 @@ class DirectRedisIntModelWithTTL(DirectRedisIntModel):
     )
 
 
-class PriorityQueueModelWithTTL(PriorityQueueModel):
-    Meta: ClassVar[RedisConfig] = RedisConfig(
-        ttl=BENCHMARK_TTL_SECONDS,
-        refresh_ttl=ActionGroup.all(for_ttl=True),
-    )
+class PriorityQueueModelNoTTL(PriorityQueueModel):
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=None)

--- a/benchmarks/test_dict.py
+++ b/benchmarks/test_dict.py
@@ -1,13 +1,18 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import StrDictModelWithTTL
 from tests.models.collection_types import StrDictModel
 
 
 class TestDictApop(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
     expected = "value"
 
-    async def setup(self):
-        model = StrDictModel(metadata={"key": "value"})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={"key": "value"})
         await model.asave()
         return model
 
@@ -16,11 +21,15 @@ class TestDictApop(AsyncBenchmarkTestWithTTL):
 
 
 class TestDictApopitem(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
     expected = "value"
 
-    async def setup(self):
-        model = StrDictModel(metadata={"key": "value"})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={"key": "value"})
         await model.asave()
         return model
 
@@ -29,10 +38,14 @@ class TestDictApopitem(AsyncBenchmarkTestWithTTL):
 
 
 class TestDictSetItem(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrDictModel(metadata={})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={})
         await model.asave()
         return model
 
@@ -41,10 +54,14 @@ class TestDictSetItem(AsyncBenchmarkTestWithTTL):
 
 
 class TestDictDelItem(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrDictModel(metadata={"key": "value"})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={"key": "value"})
         await model.asave()
         return model
 
@@ -53,10 +70,14 @@ class TestDictDelItem(AsyncBenchmarkTestWithTTL):
 
 
 class TestDictUpdate(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrDictModel(metadata={})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={})
         await model.asave()
         return model
 
@@ -65,10 +86,14 @@ class TestDictUpdate(AsyncBenchmarkTestWithTTL):
 
 
 class TestDictClear(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrDictModel,)
+    models = {
+        TTLMode.NO_TTL: StrDictModel,
+        TTLMode.TTL: StrDictModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrDictModel(metadata={"key": "value"})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(metadata={"key": "value"})
         await model.asave()
         return model
 

--- a/benchmarks/test_list.py
+++ b/benchmarks/test_list.py
@@ -1,12 +1,17 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import SimpleListModelWithTTL
 from tests.models.collection_types import SimpleListModel
 
 
 class TestListAppend(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (SimpleListModel,)
+    models = {
+        TTLMode.NO_TTL: SimpleListModel,
+        TTLMode.TTL: SimpleListModelWithTTL,
+    }
 
-    async def setup(self):
-        model = SimpleListModel(items=[])
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(items=[])
         await model.asave()
         return model
 
@@ -15,10 +20,14 @@ class TestListAppend(AsyncBenchmarkTestWithTTL):
 
 
 class TestListExtend(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (SimpleListModel,)
+    models = {
+        TTLMode.NO_TTL: SimpleListModel,
+        TTLMode.TTL: SimpleListModelWithTTL,
+    }
 
-    async def setup(self):
-        model = SimpleListModel(items=[])
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(items=[])
         await model.asave()
         return model
 
@@ -27,11 +36,15 @@ class TestListExtend(AsyncBenchmarkTestWithTTL):
 
 
 class TestListPop(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (SimpleListModel,)
+    models = {
+        TTLMode.NO_TTL: SimpleListModel,
+        TTLMode.TTL: SimpleListModelWithTTL,
+    }
     expected = "item"
 
-    async def setup(self):
-        model = SimpleListModel(items=["item"])
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(items=["item"])
         await model.asave()
         return model
 
@@ -40,10 +53,14 @@ class TestListPop(AsyncBenchmarkTestWithTTL):
 
 
 class TestListInsert(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (SimpleListModel,)
+    models = {
+        TTLMode.NO_TTL: SimpleListModel,
+        TTLMode.TTL: SimpleListModelWithTTL,
+    }
 
-    async def setup(self):
-        model = SimpleListModel(items=["a", "b"])
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(items=["a", "b"])
         await model.asave()
         return model
 
@@ -52,10 +69,14 @@ class TestListInsert(AsyncBenchmarkTestWithTTL):
 
 
 class TestListClear(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (SimpleListModel,)
+    models = {
+        TTLMode.NO_TTL: SimpleListModel,
+        TTLMode.TTL: SimpleListModelWithTTL,
+    }
 
-    async def setup(self):
-        model = SimpleListModel(items=["a", "b"])
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(items=["a", "b"])
         await model.asave()
         return model
 

--- a/benchmarks/test_model.py
+++ b/benchmarks/test_model.py
@@ -1,35 +1,48 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import IndexTestModelWithTTL, StrModelWithTTL
 from tests.models.index_types import IndexTestModel
 from tests.models.simple_types import StrModel
 
 
 class TestModelSave(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return cls(name="test")
 
     async def action(self, model):
         return await model.asave()
 
 
 class TestModelGet(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        model = self._cls(name="test")
         await model.asave()
         return model.key
 
     async def action(self, key):
-        return await StrModel.aget(key)
+        return await self._cls.aget(key)
 
 
 class TestModelLoad(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model
 
@@ -38,10 +51,14 @@ class TestModelLoad(AsyncBenchmarkTestWithTTL):
 
 
 class TestModelUpdate(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model
 
@@ -50,10 +67,14 @@ class TestModelUpdate(AsyncBenchmarkTestWithTTL):
 
 
 class TestModelDelete(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model
 
@@ -62,32 +83,44 @@ class TestModelDelete(AsyncBenchmarkTestWithTTL):
 
 
 class TestModelInsert(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return [StrModel(name=f"model_{i}") for i in range(3)]
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        return [self._cls(name=f"model_{i}") for i in range(3)]
 
     async def action(self, models):
-        return await StrModel.ainsert(*models)
+        return await self._cls.ainsert(*models)
 
 
 class TestModelFind(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        model = self._cls(name="test")
         await model.asave()
         return model.key
 
     async def action(self, key):
-        return await StrModel.afind(key)
+        return await self._cls.afind(key)
 
 
 class TestModelDuplicate(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model
 
@@ -96,44 +129,60 @@ class TestModelDuplicate(AsyncBenchmarkTestWithTTL):
 
 
 class TestModelInsertMany(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return [StrModel(name=f"model_{i}") for i in range(10)]
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        return [self._cls(name=f"model_{i}") for i in range(10)]
 
     async def action(self, models):
-        return await StrModel.ainsert(*models)
+        return await self._cls.ainsert(*models)
 
 
 class TestModelFindWithFilter(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (IndexTestModel,)
+    models = {
+        TTLMode.NO_TTL: IndexTestModel,
+        TTLMode.TTL: IndexTestModelWithTTL,
+    }
 
-    async def setup(self):
+    async def setup(self, mode):
+        self._cls = self.models[mode]
         for i in range(5):
-            model = IndexTestModel(name=f"user_{i}", age=20 + i, description="test")
+            model = self._cls(name=f"user_{i}", age=20 + i, description="test")
             await model.asave()
 
     async def action(self):
-        return await IndexTestModel.afind(IndexTestModel.age >= 22)
+        return await self._cls.afind(self._cls.age >= 22)
 
 
 class TestModelDeleteMany(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        models = [StrModel(name=f"del_{i}") for i in range(5)]
-        await StrModel.ainsert(*models)
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        models = [self._cls(name=f"del_{i}") for i in range(5)]
+        await self._cls.ainsert(*models)
         return models
 
     async def action(self, models):
-        return await StrModel.adelete_many(*models)
+        return await self._cls.adelete_many(*models)
 
 
 class TestModelDuplicateMany(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="original")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="original")
         await model.asave()
         return model
 

--- a/benchmarks/test_module_api.py
+++ b/benchmarks/test_module_api.py
@@ -1,13 +1,18 @@
 import rapyer
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import IntModelWithTTL, StrModelWithTTL
 from tests.models.simple_types import IntModel, StrModel
 
 
 class TestModuleAget(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model.key
 
@@ -16,10 +21,14 @@ class TestModuleAget(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAfindOneHit(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model.key
 
@@ -28,22 +37,30 @@ class TestModuleAfindOneHit(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAfindOneMiss(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
     expected = None
 
-    async def setup(self):
-        return "StrModel:does-not-exist"
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return f"{cls.__name__}:does-not-exist"
 
     async def action(self, key):
         return await rapyer.afind_one(key)
 
 
 class TestModuleAexistsHit(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
     expected = True
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model.key
 
@@ -52,21 +69,29 @@ class TestModuleAexistsHit(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAexistsMiss(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
     expected = False
 
-    async def setup(self):
-        return "StrModel:missing-key"
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return f"{cls.__name__}:missing-key"
 
     async def action(self, key):
         return await rapyer.aexists(key)
 
 
 class TestModuleAfindSingle(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return [model.key]
 
@@ -75,10 +100,14 @@ class TestModuleAfindSingle(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAfindMany(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        models = [StrModel(name=f"m_{i}") for i in range(10)]
+    async def setup(self, mode):
+        cls = self.models[mode]
+        models = [cls(name=f"m_{i}") for i in range(10)]
         await rapyer.ainsert(*models)
         return [m.key for m in models]
 
@@ -87,11 +116,22 @@ class TestModuleAfindMany(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAfindMixedClasses(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel, IntModel)
+    # This test exercises two model classes simultaneously. ``models`` only
+    # carries the "primary" — the secondary is fetched via ``_aux_models``.
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
+    aux_models = {
+        TTLMode.NO_TTL: IntModel,
+        TTLMode.TTL: IntModelWithTTL,
+    }
 
-    async def setup(self):
-        str_models = [StrModel(name=f"s_{i}") for i in range(5)]
-        int_models = [IntModel(count=i) for i in range(5)]
+    async def setup(self, mode):
+        str_cls = self.models[mode]
+        int_cls = self.aux_models[mode]
+        str_models = [str_cls(name=f"s_{i}") for i in range(5)]
+        int_models = [int_cls(count=i) for i in range(5)]
         await rapyer.ainsert(*str_models, *int_models)
         keys = []
         for s, i in zip(str_models, int_models):
@@ -104,31 +144,48 @@ class TestModuleAfindMixedClasses(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAinsertSingle(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return [StrModel(name="test")]
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return [cls(name="test")]
 
     async def action(self, models):
         return await rapyer.ainsert(*models)
 
 
 class TestModuleAinsertMany(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return [StrModel(name=f"m_{i}") for i in range(10)]
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return [cls(name=f"m_{i}") for i in range(10)]
 
     async def action(self, models):
         return await rapyer.ainsert(*models)
 
 
 class TestModuleAinsertMixedClasses(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel, IntModel)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
+    aux_models = {
+        TTLMode.NO_TTL: IntModel,
+        TTLMode.TTL: IntModelWithTTL,
+    }
 
-    async def setup(self):
-        str_models = [StrModel(name=f"s_{i}") for i in range(5)]
-        int_models = [IntModel(count=i) for i in range(5)]
+    async def setup(self, mode):
+        str_cls = self.models[mode]
+        int_cls = self.aux_models[mode]
+        str_models = [str_cls(name=f"s_{i}") for i in range(5)]
+        int_models = [int_cls(count=i) for i in range(5)]
         return [*str_models, *int_models]
 
     async def action(self, models):
@@ -136,10 +193,14 @@ class TestModuleAinsertMixedClasses(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAdeleteManyByKey(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        models = [StrModel(name=f"del_{i}") for i in range(5)]
+    async def setup(self, mode):
+        cls = self.models[mode]
+        models = [cls(name=f"del_{i}") for i in range(5)]
         await rapyer.ainsert(*models)
         return [m.key for m in models]
 
@@ -148,10 +209,14 @@ class TestModuleAdeleteManyByKey(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAdeleteManyByModel(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        models = [StrModel(name=f"del_{i}") for i in range(5)]
+    async def setup(self, mode):
+        cls = self.models[mode]
+        models = [cls(name=f"del_{i}") for i in range(5)]
         await rapyer.ainsert(*models)
         return models
 
@@ -160,7 +225,10 @@ class TestModuleAdeleteManyByModel(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleApipelineEmpty(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
     async def action(self):
         async with rapyer.apipeline():
@@ -168,10 +236,14 @@ class TestModuleApipelineEmpty(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleApipelineWithOps(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model.key
 
@@ -182,10 +254,14 @@ class TestModuleApipelineWithOps(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAlockFromKeyExisting(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        model = StrModel(name="test")
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(name="test")
         await model.asave()
         return model.key
 
@@ -195,10 +271,14 @@ class TestModuleAlockFromKeyExisting(AsyncBenchmarkTestWithTTL):
 
 
 class TestModuleAlockFromKeyMissing(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (StrModel,)
+    models = {
+        TTLMode.NO_TTL: StrModel,
+        TTLMode.TTL: StrModelWithTTL,
+    }
 
-    async def setup(self):
-        return "StrModel:no-such-key"
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return f"{cls.__name__}:no-such-key"
 
     async def action(self, key):
         async with rapyer.alock_from_key(key):

--- a/benchmarks/test_no_redis_actions.py
+++ b/benchmarks/test_no_redis_actions.py
@@ -1,28 +1,37 @@
-from benchmarks.base import AsyncBenchmarkTest
+from benchmarks.base import AsyncBenchmarkTest, TTLMode
 from tests.models.collection_types import SimpleListModel
 from tests.models.complex_types import OuterModel
 from tests.models.simple_types import StrModel
 
 
 class TestSetattrSimpleField(AsyncBenchmarkTest):
-    async def setup(self):
-        return StrModel(name="initial")
+    models = {TTLMode.NO_TTL: StrModel}
+
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return cls(name="initial")
 
     async def action(self, model):
         model.name = "updated"
 
 
 class TestSetattrListItem(AsyncBenchmarkTest):
-    async def setup(self):
-        return SimpleListModel(items=["initial"])
+    models = {TTLMode.NO_TTL: SimpleListModel}
+
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return cls(items=["initial"])
 
     async def action(self, model):
         model.items[0] = "updated"
 
 
 class TestSetattrNestedField(AsyncBenchmarkTest):
-    async def setup(self):
-        return OuterModel()
+    models = {TTLMode.NO_TTL: OuterModel}
+
+    async def setup(self, mode):
+        cls = self.models[mode]
+        return cls()
 
     async def action(self, model):
         model.middle_model.tags = ["new"]

--- a/benchmarks/test_numeric.py
+++ b/benchmarks/test_numeric.py
@@ -1,7 +1,10 @@
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
-from benchmarks.models import DirectRedisIntModelWithTTL, FloatModelWithTTL
+from benchmarks.models import (
+    DirectRedisIntModelWithTTL,
+    FloatModelNoTTL,
+    FloatModelWithTTL,
+)
 from tests.models.redis_types import DirectRedisIntModel
-from tests.models.simple_types import FloatModel
 
 
 class TestIntIncrease(AsyncBenchmarkTestWithTTL):
@@ -22,7 +25,7 @@ class TestIntIncrease(AsyncBenchmarkTestWithTTL):
 
 class TestFloatIncrease(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: FloatModel,
+        TTLMode.NO_TTL: FloatModelNoTTL,
         TTLMode.TTL: FloatModelWithTTL,
     }
 

--- a/benchmarks/test_numeric.py
+++ b/benchmarks/test_numeric.py
@@ -1,13 +1,18 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import DirectRedisIntModelWithTTL, FloatModelWithTTL
 from tests.models.redis_types import DirectRedisIntModel
 from tests.models.simple_types import FloatModel
 
 
 class TestIntIncrease(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (DirectRedisIntModel,)
+    models = {
+        TTLMode.NO_TTL: DirectRedisIntModel,
+        TTLMode.TTL: DirectRedisIntModelWithTTL,
+    }
 
-    async def setup(self):
-        model = DirectRedisIntModel(count=0)
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(count=0)
         await model.asave()
         return model
 
@@ -16,10 +21,14 @@ class TestIntIncrease(AsyncBenchmarkTestWithTTL):
 
 
 class TestFloatIncrease(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (FloatModel,)
+    models = {
+        TTLMode.NO_TTL: FloatModel,
+        TTLMode.TTL: FloatModelWithTTL,
+    }
 
-    async def setup(self):
-        model = FloatModel(value=0.0)
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(value=0.0)
         await model.asave()
         return model
 

--- a/benchmarks/test_numeric.py
+++ b/benchmarks/test_numeric.py
@@ -1,10 +1,7 @@
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
-from benchmarks.models import (
-    DirectRedisIntModelWithTTL,
-    FloatModelNoTTL,
-    FloatModelWithTTL,
-)
+from benchmarks.models import DirectRedisIntModelWithTTL, FloatModelNoTTL
 from tests.models.redis_types import DirectRedisIntModel
+from tests.models.simple_types import FloatModel
 
 
 class TestIntIncrease(AsyncBenchmarkTestWithTTL):
@@ -26,7 +23,7 @@ class TestIntIncrease(AsyncBenchmarkTestWithTTL):
 class TestFloatIncrease(AsyncBenchmarkTestWithTTL):
     models = {
         TTLMode.NO_TTL: FloatModelNoTTL,
-        TTLMode.TTL: FloatModelWithTTL,
+        TTLMode.TTL: FloatModel,
     }
 
     async def setup(self, mode):

--- a/benchmarks/test_pipeline.py
+++ b/benchmarks/test_pipeline.py
@@ -1,12 +1,14 @@
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
-from benchmarks.models import ComprehensiveTestModelWithTTL
-from tests.models.collection_types import ComprehensiveTestModelNoTTL
+from tests.models.collection_types import (
+    ComprehensiveTestModel,
+    ComprehensiveTestModelNoTTL,
+)
 
 
 class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
     models = {
         TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
-        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+        TTLMode.TTL: ComprehensiveTestModel,
     }
 
     async def setup(self, mode):
@@ -23,7 +25,7 @@ class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
 class TestPipelineMultipleOps(AsyncBenchmarkTestWithTTL):
     models = {
         TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
-        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+        TTLMode.TTL: ComprehensiveTestModel,
     }
 
     async def setup(self, mode):

--- a/benchmarks/test_pipeline.py
+++ b/benchmarks/test_pipeline.py
@@ -1,11 +1,11 @@
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
 from benchmarks.models import ComprehensiveTestModelWithTTL
-from tests.models.collection_types import ComprehensiveTestModel
+from tests.models.collection_types import ComprehensiveTestModelNoTTL
 
 
 class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
         TTLMode.TTL: ComprehensiveTestModelWithTTL,
     }
 
@@ -22,7 +22,7 @@ class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
 
 class TestPipelineMultipleOps(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
         TTLMode.TTL: ComprehensiveTestModelWithTTL,
     }
 

--- a/benchmarks/test_pipeline.py
+++ b/benchmarks/test_pipeline.py
@@ -1,12 +1,17 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import ComprehensiveTestModelWithTTL
 from tests.models.collection_types import ComprehensiveTestModel
 
 
 class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (ComprehensiveTestModel,)
+    models = {
+        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+    }
 
-    async def setup(self):
-        model = ComprehensiveTestModel(counter=0, name="test", tags=[], metadata={})
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(counter=0, name="test", tags=[], metadata={})
         await model.asave()
         return model
 
@@ -16,10 +21,14 @@ class TestPipelineIntIadd(AsyncBenchmarkTestWithTTL):
 
 
 class TestPipelineMultipleOps(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (ComprehensiveTestModel,)
+    models = {
+        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+    }
 
-    async def setup(self):
-        model = ComprehensiveTestModel(
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls(
             counter=0, name="test", tags=["initial"], metadata={"init": "val"}
         )
         await model.asave()

--- a/benchmarks/test_pipeline.py
+++ b/benchmarks/test_pipeline.py
@@ -28,9 +28,7 @@ class TestPipelineMultipleOps(AsyncBenchmarkTestWithTTL):
 
     async def setup(self, mode):
         cls = self.models[mode]
-        model = cls(
-            counter=0, name="test", tags=["initial"], metadata={"init": "val"}
-        )
+        model = cls(counter=0, name="test", tags=["initial"], metadata={"init": "val"})
         await model.asave()
         return model
 

--- a/benchmarks/test_pipeline_multi_model.py
+++ b/benchmarks/test_pipeline_multi_model.py
@@ -57,7 +57,9 @@ class TestMultiModelPipelineMixedOps(AsyncBenchmarkTestWithTTL):
     async def setup(self, mode):
         self._cls = self.models[mode]
         models = [
-            self._cls(counter=0, name="test", tags=["initial"], metadata={"init": "val"})
+            self._cls(
+                counter=0, name="test", tags=["initial"], metadata={"init": "val"}
+            )
             for _ in range(NUM_MODELS)
         ]
         await self._cls.ainsert(*models)

--- a/benchmarks/test_pipeline_multi_model.py
+++ b/benchmarks/test_pipeline_multi_model.py
@@ -1,7 +1,10 @@
 import rapyer
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
 from benchmarks.models import IntModelWithTTL
-from tests.models.collection_types import ComprehensiveTestModel, ComprehensiveTestModelNoTTL
+from tests.models.collection_types import (
+    ComprehensiveTestModel,
+    ComprehensiveTestModelNoTTL,
+)
 from tests.models.simple_types import IntModel
 
 NUM_MODELS = 100

--- a/benchmarks/test_pipeline_multi_model.py
+++ b/benchmarks/test_pipeline_multi_model.py
@@ -1,7 +1,7 @@
 import rapyer
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
-from benchmarks.models import ComprehensiveTestModelWithTTL, IntModelWithTTL
-from tests.models.collection_types import ComprehensiveTestModel
+from benchmarks.models import IntModelWithTTL
+from tests.models.collection_types import ComprehensiveTestModel, ComprehensiveTestModelNoTTL
 from tests.models.simple_types import IntModel
 
 NUM_MODELS = 100
@@ -28,8 +28,8 @@ class TestMultiModelPipelineIntIncrement(AsyncBenchmarkTestWithTTL):
 
 class TestMultiModelPipelineStrSet(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: ComprehensiveTestModel,
-        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+        TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
+        TTLMode.TTL: ComprehensiveTestModel,
     }
 
     async def setup(self, mode):
@@ -50,8 +50,8 @@ class TestMultiModelPipelineStrSet(AsyncBenchmarkTestWithTTL):
 
 class TestMultiModelPipelineMixedOps(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: ComprehensiveTestModel,
-        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+        TTLMode.NO_TTL: ComprehensiveTestModelNoTTL,
+        TTLMode.TTL: ComprehensiveTestModel,
     }
 
     async def setup(self, mode):

--- a/benchmarks/test_pipeline_multi_model.py
+++ b/benchmarks/test_pipeline_multi_model.py
@@ -1,5 +1,6 @@
 import rapyer
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import ComprehensiveTestModelWithTTL, IntModelWithTTL
 from tests.models.collection_types import ComprehensiveTestModel
 from tests.models.simple_types import IntModel
 
@@ -7,55 +8,65 @@ NUM_MODELS = 100
 
 
 class TestMultiModelPipelineIntIncrement(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (IntModel,)
+    models = {
+        TTLMode.NO_TTL: IntModel,
+        TTLMode.TTL: IntModelWithTTL,
+    }
 
-    async def setup(self):
-        models = [IntModel(count=0, score=100) for _ in range(NUM_MODELS)]
-        await IntModel.ainsert(*models)
+    async def setup(self, mode):
+        self._cls = self.models[mode]
+        models = [self._cls(count=0, score=100) for _ in range(NUM_MODELS)]
+        await self._cls.ainsert(*models)
         return models
 
     async def action(self, models):
         async with rapyer.apipeline():
             for model in models:
-                loaded = await IntModel.aget(model.key)
+                loaded = await self._cls.aget(model.key)
                 loaded.count += 1
 
 
 class TestMultiModelPipelineStrSet(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (ComprehensiveTestModel,)
+    models = {
+        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+    }
 
-    async def setup(self):
+    async def setup(self, mode):
+        self._cls = self.models[mode]
         models = [
-            ComprehensiveTestModel(counter=0, name="test", tags=[], metadata={})
+            self._cls(counter=0, name="test", tags=[], metadata={})
             for _ in range(NUM_MODELS)
         ]
-        await ComprehensiveTestModel.ainsert(*models)
+        await self._cls.ainsert(*models)
         return models
 
     async def action(self, models):
         async with rapyer.apipeline():
             for model in models:
-                loaded = await ComprehensiveTestModel.aget(model.key)
+                loaded = await self._cls.aget(model.key)
                 loaded.name = "updated"
 
 
 class TestMultiModelPipelineMixedOps(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (ComprehensiveTestModel,)
+    models = {
+        TTLMode.NO_TTL: ComprehensiveTestModel,
+        TTLMode.TTL: ComprehensiveTestModelWithTTL,
+    }
 
-    async def setup(self):
+    async def setup(self, mode):
+        self._cls = self.models[mode]
         models = [
-            ComprehensiveTestModel(
-                counter=0, name="test", tags=["initial"], metadata={"init": "val"}
-            )
+            self._cls(counter=0, name="test", tags=["initial"], metadata={"init": "val"})
             for _ in range(NUM_MODELS)
         ]
-        await ComprehensiveTestModel.ainsert(*models)
+        await self._cls.ainsert(*models)
         return models
 
     async def action(self, models):
         async with rapyer.apipeline():
             for model in models:
-                loaded = await ComprehensiveTestModel.aget(model.key)
+                loaded = await self._cls.aget(model.key)
                 loaded.counter += 1
                 loaded.name += "x"
                 loaded.tags.append("t")

--- a/benchmarks/test_priority_queue.py
+++ b/benchmarks/test_priority_queue.py
@@ -1,5 +1,5 @@
 from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
-from benchmarks.models import PriorityQueueModelWithTTL
+from benchmarks.models import PriorityQueueModelNoTTL
 from rapyer.types.priority_queue import PriorityQueueItem
 from tests.models.special_types import PriorityQueueModel
 
@@ -12,8 +12,8 @@ def _items(n: int) -> list[PriorityQueueItem[str]]:
 
 class PopulatedPQBenchmark(AsyncBenchmarkTestWithTTL):
     models = {
-        TTLMode.NO_TTL: PriorityQueueModel,
-        TTLMode.TTL: PriorityQueueModelWithTTL,
+        TTLMode.NO_TTL: PriorityQueueModelNoTTL,
+        TTLMode.TTL: PriorityQueueModel,
     }
 
     async def setup(self, mode):

--- a/benchmarks/test_priority_queue.py
+++ b/benchmarks/test_priority_queue.py
@@ -1,4 +1,5 @@
-from benchmarks.base import AsyncBenchmarkTestWithTTL
+from benchmarks.base import AsyncBenchmarkTestWithTTL, TTLMode
+from benchmarks.models import PriorityQueueModelWithTTL
 from rapyer.types.priority_queue import PriorityQueueItem
 from tests.models.special_types import PriorityQueueModel
 
@@ -10,10 +11,14 @@ def _items(n: int) -> list[PriorityQueueItem[str]]:
 
 
 class PopulatedPQBenchmark(AsyncBenchmarkTestWithTTL):
-    models_for_ttl = (PriorityQueueModel,)
+    models = {
+        TTLMode.NO_TTL: PriorityQueueModel,
+        TTLMode.TTL: PriorityQueueModelWithTTL,
+    }
 
-    async def setup(self):
-        model = PriorityQueueModel()
+    async def setup(self, mode):
+        cls = self.models[mode]
+        model = cls()
         await model.asave()
         await model.tasks.apush_many(_items(LARGE_PQ_SIZE))
         return model

--- a/rapyer/actions.py
+++ b/rapyer/actions.py
@@ -99,7 +99,7 @@ def register_from_result(result, action: "ActionGroup", *, initial: bool = False
     if isinstance(result, (list, tuple)):
         for item in result:
             register_action_target(item, action, initial=initial)
-    else:
+    elif result is not None:
         register_action_target(result, action, initial=initial)
 
 

--- a/rapyer/actions.py
+++ b/rapyer/actions.py
@@ -95,24 +95,12 @@ def register_action_target(
     ctx.append((model, action, initial))
 
 
-def registerable_types() -> tuple:
-    """Types the wrapper recognizes as TTL-refresh targets (lazy to avoid circular imports)."""
-    from rapyer.base import AtomicRedisModel
-    from rapyer.types.base import BaseRedisType
-
-    return AtomicRedisModel, BaseRedisType
-
-
 def register_from_result(result, action: "ActionGroup", *, initial: bool = False):
-    """RESULT-mode helper: push returned model or iterable-of-models into the context."""
-    targetable = registerable_types()
-
-    if isinstance(result, targetable):
-        register_action_target(result, action, initial=initial)
-    elif isinstance(result, (list, tuple)):
+    if isinstance(result, (list, tuple)):
         for item in result:
-            if isinstance(item, targetable):
-                register_action_target(item, action, initial=initial)
+            register_action_target(item, action, initial=initial)
+    else:
+        register_action_target(result, action, initial=initial)
 
 
 async def flush_action_targets(targets: list[ActionContextEntryType]):

--- a/rapyer/actions.py
+++ b/rapyer/actions.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 ACTION_GROUPS_ATTR = "_action_groups"
 MARK_ACTION_PARAMS_ATTR = "_mark_action_params"
+ACTION_WRAPPER_SENTINEL = "_rapyer_action_wrapper"
 
 
 @dataclass(frozen=True, slots=True)
@@ -213,6 +214,7 @@ def _build_action_wrapper(
             return result
 
     setattr(wrapper, ACTION_GROUPS_ATTR, combined)
+    setattr(wrapper, ACTION_WRAPPER_SENTINEL, True)
     return wrapper
 
 
@@ -305,12 +307,14 @@ def install_action_for_meta(func: Callable, meta: "RedisConfig"):
     params: Optional[MarkActionParams] = getattr(func, MARK_ACTION_PARAMS_ATTR, None)
     if params is None:
         return func
-    # If a parent install already wrapped this, peel back to the truly-bare
-    # function so the new decision starts fresh.
-    raw_func = func
-    while hasattr(raw_func, "__wrapped__"):
-        raw_func = raw_func.__wrapped__
-    is_async = inspect.iscoroutinefunction(raw_func)
+    # Peel back only past wrappers WE installed previously (e.g. parent class
+    # install of the same method with a different meta). Other wrappers like
+    # ``marks_redis_updated`` must stay in place so the call chain is preserved
+    # — both for the wrap branch and the no-wrap branch.
+    base_func = func
+    while getattr(base_func, ACTION_WRAPPER_SENTINEL, False):
+        base_func = base_func.__wrapped__
+    is_async = inspect.iscoroutinefunction(base_func)
     should_refresh = (
         not params.ignore_refresh
         and is_async
@@ -319,13 +323,20 @@ def install_action_for_meta(func: Callable, meta: "RedisConfig"):
     should_start_ttl = params.initial and meta.ttl and is_async
     if should_refresh or should_start_ttl:
         return _build_action_wrapper(
-            raw_func, params.combined, params.target, params.initial
+            base_func, params.combined, params.target, params.initial
         )
-    return raw_func
+    return base_func
 
 
-def install_marked_action_methods(cls: type["AtomicRedisModel"]):
-    """Wrap methods that need ttl handling"""
+def install_marked_action_methods(cls: type, meta: Optional["RedisConfig"] = None):
+    """Wrap methods that need ttl handling.
+
+    When ``meta`` is omitted, falls back to ``cls.Meta`` (the AtomicRedisModel
+    path). For BaseRedisType field subclasses, the owning model's meta is
+    passed in explicitly because they don't carry their own ``Meta`` class.
+    """
+    if meta is None:
+        meta = cls.Meta
     seen: set[str] = set()
     for klass in cls.__mro__:
         if klass is object:
@@ -347,7 +358,7 @@ def install_marked_action_methods(cls: type["AtomicRedisModel"]):
                 continue
             if not hasattr(raw_func, MARK_ACTION_PARAMS_ATTR):
                 continue
-            installed = install_action_for_meta(raw_func, cls.Meta)
+            installed = install_action_for_meta(raw_func, meta)
             if rebuild is not None:
                 installed = rebuild(installed)
             setattr(cls, name, installed)

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -320,6 +320,7 @@ class AtomicRedisModel(BaseModel):
                     f".{field_name}",
                     safe_load=field_name in cls._safe_load_fields
                     or cls.Meta.safe_load_all,
+                    owner_meta=cls.Meta,
                 ),
             )
             for field_name, annotation in original_annotations.items()

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -3,7 +3,7 @@ import base64
 import logging
 import pickle
 from abc import ABC
-from typing import Any, Generic, TypeVar, get_args
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, get_args
 
 from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import core_schema
@@ -11,10 +11,13 @@ from pydantic_core.core_schema import CoreSchema, SerializationInfo, ValidationI
 from redis.commands.search.field import TextField
 
 # Imported here to avoid circular import issues; actions imports context, not types.base
-from rapyer.actions import ActionGroup, mark_actions
+from rapyer.actions import ActionGroup, install_marked_action_methods, mark_actions
 from rapyer.context import _context_pipe
 from rapyer.errors import CantSerializeRedisValueError
 from rapyer.typing_support import Self
+
+if TYPE_CHECKING:
+    from rapyer.config import RedisConfig
 
 logger = logging.getLogger("rapyer")
 
@@ -29,6 +32,15 @@ class BaseRedisType(ABC):
     original_type: type = None
     field_name: str = None
     _adapter: TypeAdapter = None
+
+    def __init_subclass__(cls, *, owner_meta: Optional["RedisConfig"] = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if owner_meta is None:
+            # Static (module-load-time) subclass — no Atomic to specialize for yet.
+            # Methods stay tagged with v2 MarkActionParams; the dynamic per-field
+            # subclass created by RedisConverter will install them with its meta.
+            return
+        install_marked_action_methods(cls, owner_meta)
 
     @property
     def redis(self):

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -87,7 +87,7 @@ class BaseRedisType(ABC):
 
 class RedisType(BaseRedisType):
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     async def asave(self) -> Self:
         model_dump = self._adapter.dump_python(
             self, mode="json", context={REDIS_DUMP_FLAG_NAME: True}
@@ -95,7 +95,7 @@ class RedisType(BaseRedisType):
         await self.client.json().set(self.key, self.json_path, model_dump)  # type: ignore[misc]
         return self
 
-    @mark_actions(ActionGroup.READ)
+    @mark_actions(ActionGroup.READ, version="v2")
     async def aload(self):
         redis_value = await self.redis.json().get(self.key, self.field_path)  # type: ignore[misc]
         if redis_value is None:

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -40,7 +40,19 @@ class BaseRedisType(ABC):
             # Methods stay tagged with v2 MarkActionParams; the dynamic per-field
             # subclass created by RedisConverter will install them with its meta.
             return
-        install_marked_action_methods(cls, owner_meta)
+        cls.build_redis_model(owner_meta)
+
+    @classmethod
+    def build_redis_model(cls, meta: "RedisConfig"):
+        """Re-install marked-action methods on this per-field subclass.
+
+        Mirror of ``AtomicRedisModel.build_redis_model`` for the field-type
+        side: dynamic per-field subclasses (created by ``RedisConverter``)
+        decide wrap/no-wrap of each method against the owning model's meta at
+        build time. Tests/benchmarks that mutate ``Meta`` at runtime can call
+        this directly via the test-side ``recursive_build_redis_model`` helper.
+        """
+        install_marked_action_methods(cls, meta)
 
     @property
     def redis(self):

--- a/rapyer/types/byte.py
+++ b/rapyer/types/byte.py
@@ -14,7 +14,7 @@ class RedisBytes(bytes, RedisType):
         return bytes(self)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def __iadd__(self, other):
         new_value = self + other
         if self.pipeline:

--- a/rapyer/types/convert.py
+++ b/rapyer/types/convert.py
@@ -1,4 +1,5 @@
-from typing import get_origin
+import types as _python_types
+from typing import TYPE_CHECKING, Optional, get_origin
 
 from pydantic import BaseModel, PrivateAttr, TypeAdapter
 
@@ -8,6 +9,9 @@ from rapyer.types.special import SpecialFieldType
 from rapyer.utils.annotation import DYNAMIC_CLASS_DOC, TypeConverter
 from rapyer.utils.pythonic import safe_issubclass
 
+if TYPE_CHECKING:
+    from rapyer.config import RedisConfig
+
 
 class RedisConverter(TypeConverter):
     def __init__(
@@ -15,10 +19,22 @@ class RedisConverter(TypeConverter):
         supported_types: dict[type, type],
         field_name: str,
         safe_load: bool = False,
+        owner_meta: Optional["RedisConfig"] = None,
     ):
         self.supported_types = supported_types
         self.field_name = field_name
         self.safe_load = safe_load
+        self.owner_meta = owner_meta
+
+    def _build_redis_subclass(self, name: str, base: type, namespace: dict) -> type:
+        """Create a per-field BaseRedisType subclass and pass owner_meta into __init_subclass__."""
+        kwds = {"owner_meta": self.owner_meta} if self.owner_meta is not None else {}
+        return _python_types.new_class(
+            name,
+            bases=(base,),
+            kwds=kwds,
+            exec_body=lambda ns: ns.update(namespace),
+        )
 
     def is_redis_type(self, type_to_check: type) -> bool:
         origin = get_origin(type_to_check) or type_to_check
@@ -66,9 +82,9 @@ class RedisConverter(TypeConverter):
             redis_type = self.supported_types[type_to_convert]
             original_type = type_to_convert
 
-        new_type = type(
+        new_type = self._build_redis_subclass(
             redis_type.__name__,
-            (redis_type,),
+            redis_type,
             dict(
                 field_name=self.field_name,
                 original_type=original_type,
@@ -92,9 +108,9 @@ class RedisConverter(TypeConverter):
             original_type = type_to_covert
             original_type = original_type[generic_values]
 
-        new_type = type(
+        new_type = self._build_redis_subclass(
             redis_type.__name__,
-            (redis_type,),
+            redis_type,
             dict(
                 field_name=self.field_name,
                 original_type=original_type,

--- a/rapyer/types/datetime.py
+++ b/rapyer/types/datetime.py
@@ -34,7 +34,7 @@ class RedisDatetime(datetime, RedisType):
         return datetime.fromtimestamp(self.timestamp())
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __iadd__(self, other: timedelta) -> "RedisDatetime":
         if not isinstance(other, timedelta):
             return NotImplemented
@@ -52,7 +52,7 @@ class RedisDatetime(datetime, RedisType):
         return new_value
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __isub__(self, other: timedelta) -> "RedisDatetime":
         if not isinstance(other, timedelta):
             return NotImplemented
@@ -109,7 +109,7 @@ class RedisDatetimeTimestamp(RedisDatetime):
         return NumericField(f"$.{field_name}", as_name=field_name)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __iadd__(self, other: timedelta) -> "RedisDatetimeTimestamp":
         if not isinstance(other, timedelta):
             return NotImplemented
@@ -122,7 +122,7 @@ class RedisDatetimeTimestamp(RedisDatetime):
         return new_value
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __isub__(self, other: timedelta) -> "RedisDatetimeTimestamp":
         if not isinstance(other, timedelta):
             return NotImplemented

--- a/rapyer/types/dct.py
+++ b/rapyer/types/dct.py
@@ -44,7 +44,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
                 self.init_redis_field(f".{key}", value)
         return new_dct
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     def update(self, m=None, /, **kwargs):
         if self.pipeline:
             m_redis_val = (
@@ -66,13 +66,13 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
         kwargs_new_val = self.validate_dict(kwargs)
         return super().update(m_new_val, **kwargs_new_val)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     def clear(self):
         if self.pipeline:
             self.pipeline.json().set(self.key, self.json_path, {})
         return super().clear()
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     def __setitem__(self, key, value):
         if self.pipeline:
             serialized = self._adapter.dump_python(
@@ -84,7 +84,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
         new_val = self.validate_dict({key: value})[key]
         super().__setitem__(key, new_val)
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     async def aset_item(self, key, value):
         self.__setitem__(key, value)
 
@@ -97,13 +97,13 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
         )
         return result
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     async def adel_item(self, key):
         super().__delitem__(key)
         result = await self.client.json().delete(self.key, self.json_field_path(key))  # type: ignore[misc]
         return result
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     async def aupdate(self, **kwargs):
         self.update(**kwargs)
 
@@ -118,7 +118,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
                 update_keys_in_pipeline(pipeline, self.key, **redis_params)
                 await pipeline.execute()
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ, version="v2")
     async def apop(self, key, default=None):
         result = await arun_sha(
             self.redis,
@@ -138,7 +138,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
             {key: result}, context={REDIS_DUMP_FLAG_NAME: True}
         )[key]
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ, version="v2")
     async def apopitem(self):
         result = await arun_sha(
             self.redis,
@@ -162,7 +162,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
             # If Redis is empty but local dict has items, raise an error for consistency
             raise KeyError("popitem(): dictionary is empty")
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     async def aclear(self):
         self.clear()
         # Clear Redis dict

--- a/rapyer/types/float.py
+++ b/rapyer/types/float.py
@@ -21,7 +21,7 @@ class RedisFloat(float, RedisType):
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     async def aincrease(self, amount: float = 1.0):
         result = await self.client.json().numincrby(self.key, self.json_path, amount)  # type: ignore[misc]
         return result[0] if isinstance(result, list) and result else result
@@ -30,7 +30,7 @@ class RedisFloat(float, RedisType):
         return float(self)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __iadd__(self, other):
         new_value = self + other
         if self.pipeline:
@@ -38,7 +38,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __isub__(self, other):
         new_value = self - other
         if self.pipeline:
@@ -46,7 +46,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __imul__(self, other):
         new_value = self * other
         if self.pipeline:
@@ -56,7 +56,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __itruediv__(self, other):
         new_value = self / other
         if self.pipeline:
@@ -71,7 +71,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __ifloordiv__(self, other):
         new_value = self // other
         if self.pipeline:
@@ -86,7 +86,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __imod__(self, other):
         new_value = self % other
         if self.pipeline:
@@ -96,7 +96,7 @@ class RedisFloat(float, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __ipow__(self, other):
         new_value = self**other
         if self.pipeline:

--- a/rapyer/types/integer.py
+++ b/rapyer/types/integer.py
@@ -20,7 +20,7 @@ class RedisInt(int, RedisType):
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     async def aincrease(self, amount: int = 1):
         result = await self.client.json().numincrby(self.key, self.json_path, amount)  # type: ignore[misc]
         return result[0] if isinstance(result, list) and result else result
@@ -29,7 +29,7 @@ class RedisInt(int, RedisType):
         return int(self)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __iadd__(self, other):
         if self.pipeline:
             self.pipeline.json().numincrby(self.key, self.json_path, other)
@@ -37,7 +37,7 @@ class RedisInt(int, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __isub__(self, other):
         if self.pipeline:
             self.pipeline.json().numincrby(self.key, self.json_path, -other)
@@ -45,7 +45,7 @@ class RedisInt(int, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __imul__(self, other):
         new_value = self * other
         if self.pipeline:
@@ -55,7 +55,7 @@ class RedisInt(int, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __ifloordiv__(self, other):
         new_value = self // other
         if self.pipeline:
@@ -70,7 +70,7 @@ class RedisInt(int, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __imod__(self, other):
         new_value = self % other
         if self.pipeline:
@@ -80,7 +80,7 @@ class RedisInt(int, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ARITHMETIC, version="v2")
     def __ipow__(self, other):
         new_value = self**other
         if self.pipeline:

--- a/rapyer/types/lst.py
+++ b/rapyer/types/lst.py
@@ -47,7 +47,7 @@ class RedisList(list, GenericRedisType[T]):
     def sub_field_path(self, key: str):
         return f"{self.field_path}[{key}]"
 
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     def __setitem__(self, key, value):
         if self.pipeline:
             serialized = self._adapter.dump_python(
@@ -58,12 +58,12 @@ class RedisList(list, GenericRedisType[T]):
         return super().__setitem__(key, new_val)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def __iadd__(self, other):
         self.extend(other)
         return self
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def append(self, __object):
         if self.pipeline:
             serialized_object = self._adapter.dump_python(
@@ -76,7 +76,7 @@ class RedisList(list, GenericRedisType[T]):
         new_val = self.create_new_value(key, __object)
         return super().append(new_val)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def extend(self, new_lst):
         if self.pipeline and new_lst:
             serialized = self._adapter.dump_python(
@@ -87,7 +87,7 @@ class RedisList(list, GenericRedisType[T]):
         new_vals = self.create_new_values(list(new_keys), new_lst)
         return super().extend(new_vals)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def insert(self, index, __object):
         if self.pipeline:
             serialized = self._adapter.dump_python(
@@ -99,13 +99,13 @@ class RedisList(list, GenericRedisType[T]):
         new_val = self.create_new_value(index, __object)
         return super().insert(index, new_val)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     def clear(self):
         if self.pipeline:
             self.pipeline.json().set(self.key, self.json_path, [])
         return super().clear()
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     def remove_range(self, start: int, end: int):
         if self.pipeline:
             run_sha(
@@ -124,7 +124,7 @@ class RedisList(list, GenericRedisType[T]):
                 "No changes were made. Use 'async with model.apipeline():' to execute."
             )
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     async def aappend(self, __object):
         self.append(__object)
 
@@ -137,7 +137,7 @@ class RedisList(list, GenericRedisType[T]):
                 self.key, self.json_path, *serialized_object
             )
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     async def aextend(self, __iterable):
         items = list(__iterable)
         self.extend(items)
@@ -154,7 +154,7 @@ class RedisList(list, GenericRedisType[T]):
                 *serialized_items,
             )
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ, version="v2")
     async def apop(self, index=-1):
         if self:
             self.pop(index)
@@ -168,7 +168,7 @@ class RedisList(list, GenericRedisType[T]):
             arrpop, context={REDIS_DUMP_FLAG_NAME: True}
         )[0]
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     async def ainsert(self, index, __object):
         self.insert(index, __object)
 
@@ -181,7 +181,7 @@ class RedisList(list, GenericRedisType[T]):
                 self.key, self.json_path, index, *serialized_object
             )
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     async def aclear(self):
         # Clear local list
         self.clear()

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -45,17 +45,17 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
 
     # --- Queue operations ---
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     async def apush(self, value: T, priority: float):
         serialized = self._serialize_value(value)
         await self.client.zadd(self.special_key, {serialized: priority})
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     async def apush_many(self, items: list[PriorityQueueItem[T]]):
         mapping = {self._serialize_value(item.value): item.priority for item in items}
         await self.client.zadd(self.special_key, mapping)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, ActionGroup.READ, version="v2")
     async def apop(self):
         result = await self.redis.zpopmin(self.special_key, count=1)
         if not result:
@@ -63,7 +63,7 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
         member, score = result[0]
         return self._deserialize_value(member)
 
-    @mark_actions(ActionGroup.READ)
+    @mark_actions(ActionGroup.READ, version="v2")
     async def apeek(self):
         result = await self.redis.zrange(self.special_key, 0, 0, withscores=True)
         if not result:
@@ -71,15 +71,15 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
         member, score = result[0]
         return self._deserialize_value(member)
 
-    @mark_actions(ActionGroup.READ)
+    @mark_actions(ActionGroup.READ, version="v2")
     async def asize(self) -> int:
         return await self.redis.zcard(self.special_key)
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     async def aclear(self):
         await self.client.delete(self.special_key)
 
-    @mark_actions(ActionGroup.READ)
+    @mark_actions(ActionGroup.READ, version="v2")
     async def aitems(self) -> list[PriorityQueueItem]:
         result = await self.redis.zrange(self.special_key, 0, -1, withscores=True)
         return [
@@ -87,7 +87,7 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
             for m, s in result
         ]
 
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.ERASE, version="v2")
     async def aremove(self, value) -> Optional[bool]:
         serialized = self._serialize_value(value)
         removed = await self.client.zrem(self.special_key, serialized)

--- a/rapyer/types/string.py
+++ b/rapyer/types/string.py
@@ -12,7 +12,7 @@ class RedisStr(str, RedisType):
         return str(self)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND)
+    @mark_actions(ActionGroup.UPDATE, ActionGroup.APPEND, version="v2")
     def __iadd__(self, other):
         new_value = self + other
         if self.pipeline:
@@ -27,7 +27,7 @@ class RedisStr(str, RedisType):
         return self.__class__(new_value)
 
     @marks_redis_updated
-    @mark_actions(ActionGroup.UPDATE)
+    @mark_actions(ActionGroup.UPDATE, version="v2")
     def __imul__(self, other):
         new_value = self * other
         if self.pipeline:

--- a/tests/build_helpers.py
+++ b/tests/build_helpers.py
@@ -1,21 +1,3 @@
-"""Test/benchmark helpers for rebuilding redis models after mutating ``Meta``.
-
-The model class's own ``build_redis_model`` only re-installs marked-action
-methods on the model class itself. Per-field ``BaseRedisType`` subclasses are
-specialized once (in their ``__init_subclass__``) against the owning model's
-``Meta`` snapshot at class-definition time, so they don't pick up later
-mutations to ``Meta.ttl`` / ``Meta.refresh_ttl``.
-
-``recursive_build_redis_model`` walks the fields and rebuilds every dynamic
-``BaseRedisType`` subclass with the model's current ``Meta``. It's intentionally
-test-side (not in the runtime path) — production code should set ``Meta`` at
-class-definition time.
-
-Caller responsibility: the helper walks **all** fields including inherited
-ones. When two classes in an inheritance hierarchy share a per-field subclass
-and have diverging ``Meta``, only call this on the field-owning class.
-"""
-
 from typing import get_args, get_origin
 
 from rapyer.base import AtomicRedisModel
@@ -32,14 +14,29 @@ def _iter_annotation_types(annotation):
         yield from _iter_annotation_types(arg)
 
 
-def recursive_build_redis_model(cls: type[AtomicRedisModel]):
-    """Rebuild ``cls`` and its dynamic per-field ``BaseRedisType`` subclasses."""
+def recursive_build_redis_model(
+    cls: type[AtomicRedisModel],
+    _seen: set[int] | None = None,
+):
+    """Rebuild ``cls``, its per-field ``BaseRedisType`` subclasses, and any
+    nested ``AtomicRedisModel`` fields (each rebuilt against its own ``Meta``).
+    """
+    if _seen is None:
+        _seen = set()
+    if id(cls) in _seen:
+        return
+    _seen.add(id(cls))
+
     cls.build_redis_model()
-    seen: set[int] = set()
     for field_info in cls.model_fields.values():
         for t in _iter_annotation_types(field_info.annotation):
-            if id(t) in seen:
+            if id(t) in _seen:
                 continue
-            seen.add(id(t))
             if issubclass(t, BaseRedisType):
+                _seen.add(id(t))
                 t.build_redis_model(cls.Meta)
+            elif issubclass(t, AtomicRedisModel):
+                # Nested model — recurse with its own Meta. Don't mark it
+                # ``_seen`` here; the recursive call does that to also block
+                # re-entry from inside the nested walk.
+                recursive_build_redis_model(t, _seen)

--- a/tests/build_helpers.py
+++ b/tests/build_helpers.py
@@ -1,0 +1,45 @@
+"""Test/benchmark helpers for rebuilding redis models after mutating ``Meta``.
+
+The model class's own ``build_redis_model`` only re-installs marked-action
+methods on the model class itself. Per-field ``BaseRedisType`` subclasses are
+specialized once (in their ``__init_subclass__``) against the owning model's
+``Meta`` snapshot at class-definition time, so they don't pick up later
+mutations to ``Meta.ttl`` / ``Meta.refresh_ttl``.
+
+``recursive_build_redis_model`` walks the fields and rebuilds every dynamic
+``BaseRedisType`` subclass with the model's current ``Meta``. It's intentionally
+test-side (not in the runtime path) — production code should set ``Meta`` at
+class-definition time.
+
+Caller responsibility: the helper walks **all** fields including inherited
+ones. When two classes in an inheritance hierarchy share a per-field subclass
+and have diverging ``Meta``, only call this on the field-owning class.
+"""
+
+from typing import get_args, get_origin
+
+from rapyer.base import AtomicRedisModel
+from rapyer.types.base import BaseRedisType
+
+
+def _iter_annotation_types(annotation):
+    if isinstance(annotation, type):
+        yield annotation
+    origin = get_origin(annotation)
+    if isinstance(origin, type):
+        yield origin
+    for arg in get_args(annotation):
+        yield from _iter_annotation_types(arg)
+
+
+def recursive_build_redis_model(cls: type[AtomicRedisModel]):
+    """Rebuild ``cls`` and its dynamic per-field ``BaseRedisType`` subclasses."""
+    cls.build_redis_model()
+    seen: set[int] = set()
+    for field_info in cls.model_fields.values():
+        for t in _iter_annotation_types(field_info.annotation):
+            if id(t) in seen:
+                continue
+            seen.add(id(t))
+            if issubclass(t, BaseRedisType):
+                t.build_redis_model(cls.Meta)

--- a/tests/unit/mark_actions/test_reinstall.py
+++ b/tests/unit/mark_actions/test_reinstall.py
@@ -1,0 +1,200 @@
+from rapyer import AtomicRedisModel
+from rapyer.actions import ACTION_WRAPPER_SENTINEL, MARK_ACTION_PARAMS_ATTR, ActionGroup
+from rapyer.config import RedisConfig
+from rapyer.types.integer import RedisInt
+from tests.build_helpers import recursive_build_redis_model
+
+
+def _count_action_wrappers(func):
+    """Count action wrappers in the ``__wrapped__`` chain. Anything more than
+    one means a previous install layer was stacked on top instead of peeled."""
+    count = 0
+    current = func
+    while current is not None:
+        if getattr(current, ACTION_WRAPPER_SENTINEL, False):
+            count += 1
+        current = getattr(current, "__wrapped__", None)
+    return count
+
+
+def test_inheriting_models_with_redis_int_keep_marks_redis_updated_wrapper():
+    # Arrange — contradicting configs: parent refreshes on UPDATE/READ, child
+    # on APPEND/ARITHMETIC. Both keep ``ttl=60`` so refresh decisions actually
+    # fire (``ttl=None`` would short-circuit ``should_refresh_for_action``).
+    class PeelParentModel(AtomicRedisModel):
+        Meta = RedisConfig(
+            ttl=60,
+            refresh_ttl=ActionGroup.UPDATE | ActionGroup.READ,
+            init_with_rapyer=False,
+        )
+        counter: int = 0
+
+    class PeelChildModel(PeelParentModel):
+        Meta = RedisConfig(
+            ttl=60,
+            refresh_ttl=ActionGroup.APPEND | ActionGroup.ARITHMETIC,
+            init_with_rapyer=False,
+        )
+
+    # Assert — pick a few representative methods and check wrap counts.
+
+    # ``aload`` is marked READ: parent wraps, child peels (READ ∉ APPEND|ARITHMETIC).
+    assert _count_action_wrappers(vars(PeelParentModel)["aload"]) == 1
+    assert _count_action_wrappers(vars(PeelChildModel)["aload"]) == 0
+
+    # ``aupdate`` is marked UPDATE: same contradiction as aload.
+    assert _count_action_wrappers(vars(PeelParentModel)["aupdate"]) == 1
+    assert _count_action_wrappers(vars(PeelChildModel)["aupdate"]) == 0
+
+    # ``asave`` is UPDATE|CREATE with ``initial=True``. Both metas wrap (parent
+    # via UPDATE match, child via initial+ttl). Wrap count must still be 1 on
+    # the child — the install peeled parent's wrapper before re-wrapping.
+    assert _count_action_wrappers(vars(PeelParentModel)["asave"]) == 1
+    assert _count_action_wrappers(vars(PeelChildModel)["asave"]) == 1
+    assert vars(PeelChildModel)["asave"] is not vars(PeelParentModel)["asave"]
+
+    # ``aset_ttl`` carries ``ignore_refresh=True`` — never wrapped, regardless
+    # of meta. If install ever stacked a wrapper here, count would be 1.
+    assert _count_action_wrappers(vars(PeelParentModel)["aset_ttl"]) == 0
+    assert _count_action_wrappers(vars(PeelChildModel)["aset_ttl"]) == 0
+
+    # Per-field RedisInt subclass: built once with parent meta, reused by
+    # child. The methods inherited from RedisType / BaseRedisType (``asave``,
+    # ``aload``) and the RedisInt-specific async ``aincrease`` must all wrap
+    # exactly once under parent's UPDATE|READ meta.
+    field_type = PeelParentModel.model_fields["counter"].annotation
+    assert PeelChildModel.model_fields["counter"].annotation is field_type
+    assert issubclass(field_type, RedisInt)
+
+    # ``RedisType.asave`` (UPDATE) — wraps under parent meta.
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
+    # ``RedisType.aload`` (READ) — wraps under parent meta.
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 1
+    # ``RedisInt.aincrease`` (UPDATE|ARITHMETIC, async) — wraps via UPDATE match.
+    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 1
+
+    # Sync ``__iadd__`` / ``__isub__`` are wrapped with ``marks_redis_updated``.
+    # install must leave them as that exact wrapper — no action wrapper added,
+    # ``marks_redis_updated`` not stripped.
+    for op_name in ("__iadd__", "__isub__"):
+        redis_int_op = vars(RedisInt)[op_name]
+        installed_op = vars(field_type)[op_name]
+        assert installed_op is redis_int_op, (
+            f"per-field {op_name} was replaced — peel-back stripped the "
+            "marks_redis_updated wrapper."
+        )
+        assert _count_action_wrappers(installed_op) == 0
+        assert hasattr(installed_op, MARK_ACTION_PARAMS_ATTR)
+        assert hasattr(installed_op, "__wrapped__")
+
+
+def test_recursive_build_redis_model_picks_up_runtime_meta_ttl_mutation():
+    # Arrange — model has ``ttl=None`` at class-definition time, so the
+    # per-field RedisInt subclass is built with the bare (unwrapped) methods.
+    class RuntimeTtlModel(AtomicRedisModel):
+        Meta = RedisConfig(
+            ttl=None,
+            refresh_ttl=ActionGroup.UPDATE,
+            init_with_rapyer=False,
+        )
+        counter: int = 0
+
+    field_type = RuntimeTtlModel.model_fields["counter"].annotation
+
+    # Pre-condition — bare, no wrapper installed.
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 0
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
+    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 0
+
+    # Act — mutate Meta at runtime then call the recursive helper.
+    RuntimeTtlModel.Meta.ttl = 60
+    recursive_build_redis_model(RuntimeTtlModel)
+
+    # Assert — wrappers now applied to field methods whose action group
+    # matches ``refresh_ttl`` (UPDATE).
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
+    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 1
+    # READ doesn't match UPDATE-only refresh_ttl → still bare.
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
+
+    # Act — revert ttl to None and rebuild.
+    RuntimeTtlModel.Meta.ttl = None
+    recursive_build_redis_model(RuntimeTtlModel)
+
+    # Assert — wrappers peeled back to bare.
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 0
+    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 0
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
+
+
+def test_recursive_build_redis_model_recurses_into_nested_atomic_model():
+    # Arrange — both Outer and Inner start without TTL. The nested model gets
+    # its own dynamic subclass with its own Meta when Outer is defined.
+    class Inner(AtomicRedisModel):
+        Meta = RedisConfig(
+            ttl=None,
+            refresh_ttl=ActionGroup.UPDATE,
+            init_with_rapyer=False,
+        )
+        counter: int = 0
+
+    class Outer(AtomicRedisModel):
+        Meta = RedisConfig(
+            ttl=None,
+            refresh_ttl=ActionGroup.UPDATE,
+            init_with_rapyer=False,
+        )
+        inner: Inner
+
+    inner_dynamic = Outer.model_fields["inner"].annotation
+    inner_counter_type = inner_dynamic.model_fields["counter"].annotation
+
+    # Pre-condition — bare on every level.
+    assert _count_action_wrappers(vars(inner_counter_type)["asave"]) == 0
+
+    # Act — mutate ONLY Inner's Meta, then run recursive rebuild on Outer.
+    # The recursion should pick up the inner model and rebuild its field types
+    # against Inner's (now-TTLed) Meta, not Outer's.
+    Inner.Meta.ttl = 60
+    inner_dynamic.Meta.ttl = 60
+    recursive_build_redis_model(Outer)
+
+    # Assert — inner's per-field RedisInt got re-installed with TTL,
+    # picked up via Inner's Meta (Outer's Meta is still ttl=None).
+    assert Outer.Meta.ttl is None
+    assert _count_action_wrappers(vars(inner_counter_type)["asave"]) == 1
+
+
+def test_plain_build_redis_model_on_child_does_not_touch_parent_field_install():
+    # Arrange — parent + child share a per-field type. Parent owns the field;
+    # child only differs in Meta. ``cls.build_redis_model()`` (the model-only
+    # rebuild) must not touch the shared field type — that's reserved for the
+    # opt-in ``recursive_build_redis_model`` test helper.
+    class OwnerModel(AtomicRedisModel):
+        Meta = RedisConfig(
+            ttl=60,
+            refresh_ttl=ActionGroup.UPDATE,
+            init_with_rapyer=False,
+        )
+        counter: int = 0
+
+    class HeirModel(OwnerModel):
+        Meta = RedisConfig(
+            ttl=60,
+            refresh_ttl=ActionGroup.READ,  # contradicts parent
+            init_with_rapyer=False,
+        )
+
+    field_type = OwnerModel.model_fields["counter"].annotation
+    assert HeirModel.model_fields["counter"].annotation is field_type
+
+    # Pre-condition — installed under parent's UPDATE meta.
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
+
+    # Act — child rebuilds via the model-only rebuild.
+    HeirModel.build_redis_model()
+
+    # Assert — parent's installation is untouched.
+    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
+    assert _count_action_wrappers(vars(field_type)["aload"]) == 0

--- a/tests/unit/mark_actions/test_reinstall.py
+++ b/tests/unit/mark_actions/test_reinstall.py
@@ -84,7 +84,7 @@ def test_inheriting_models_with_redis_int_keep_marks_redis_updated_wrapper():
         assert hasattr(installed_op, "__wrapped__")
 
 
-def test_recursive_build_redis_model_recurses_into_nested_atomic_model():
+def test_recursive_model_recurses_into_nested_atomic_model():
     # Act
     class Inner(AtomicRedisModel):
         Meta = RedisConfig(

--- a/tests/unit/mark_actions/test_reinstall.py
+++ b/tests/unit/mark_actions/test_reinstall.py
@@ -2,7 +2,6 @@ from rapyer import AtomicRedisModel
 from rapyer.actions import ACTION_WRAPPER_SENTINEL, MARK_ACTION_PARAMS_ATTR, ActionGroup
 from rapyer.config import RedisConfig
 from rapyer.types.integer import RedisInt
-from tests.build_helpers import recursive_build_redis_model
 
 
 def _count_action_wrappers(func):
@@ -18,9 +17,7 @@ def _count_action_wrappers(func):
 
 
 def test_inheriting_models_with_redis_int_keep_marks_redis_updated_wrapper():
-    # Arrange — contradicting configs: parent refreshes on UPDATE/READ, child
-    # on APPEND/ARITHMETIC. Both keep ``ttl=60`` so refresh decisions actually
-    # fire (``ttl=None`` would short-circuit ``should_refresh_for_action``).
+    # Act
     class PeelParentModel(AtomicRedisModel):
         Meta = RedisConfig(
             ttl=60,
@@ -36,8 +33,7 @@ def test_inheriting_models_with_redis_int_keep_marks_redis_updated_wrapper():
             init_with_rapyer=False,
         )
 
-    # Assert — pick a few representative methods and check wrap counts.
-
+    # Assert
     # ``aload`` is marked READ: parent wraps, child peels (READ ∉ APPEND|ARITHMETIC).
     assert _count_action_wrappers(vars(PeelParentModel)["aload"]) == 1
     assert _count_action_wrappers(vars(PeelChildModel)["aload"]) == 0
@@ -88,51 +84,11 @@ def test_inheriting_models_with_redis_int_keep_marks_redis_updated_wrapper():
         assert hasattr(installed_op, "__wrapped__")
 
 
-def test_recursive_build_redis_model_picks_up_runtime_meta_ttl_mutation():
-    # Arrange — model has ``ttl=None`` at class-definition time, so the
-    # per-field RedisInt subclass is built with the bare (unwrapped) methods.
-    class RuntimeTtlModel(AtomicRedisModel):
-        Meta = RedisConfig(
-            ttl=None,
-            refresh_ttl=ActionGroup.UPDATE,
-            init_with_rapyer=False,
-        )
-        counter: int = 0
-
-    field_type = RuntimeTtlModel.model_fields["counter"].annotation
-
-    # Pre-condition — bare, no wrapper installed.
-    assert _count_action_wrappers(vars(field_type)["asave"]) == 0
-    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
-    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 0
-
-    # Act — mutate Meta at runtime then call the recursive helper.
-    RuntimeTtlModel.Meta.ttl = 60
-    recursive_build_redis_model(RuntimeTtlModel)
-
-    # Assert — wrappers now applied to field methods whose action group
-    # matches ``refresh_ttl`` (UPDATE).
-    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
-    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 1
-    # READ doesn't match UPDATE-only refresh_ttl → still bare.
-    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
-
-    # Act — revert ttl to None and rebuild.
-    RuntimeTtlModel.Meta.ttl = None
-    recursive_build_redis_model(RuntimeTtlModel)
-
-    # Assert — wrappers peeled back to bare.
-    assert _count_action_wrappers(vars(field_type)["asave"]) == 0
-    assert _count_action_wrappers(vars(field_type)["aincrease"]) == 0
-    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
-
-
 def test_recursive_build_redis_model_recurses_into_nested_atomic_model():
-    # Arrange — both Outer and Inner start without TTL. The nested model gets
-    # its own dynamic subclass with its own Meta when Outer is defined.
+    # Act
     class Inner(AtomicRedisModel):
         Meta = RedisConfig(
-            ttl=None,
+            ttl=66,
             refresh_ttl=ActionGroup.UPDATE,
             init_with_rapyer=False,
         )
@@ -149,52 +105,9 @@ def test_recursive_build_redis_model_recurses_into_nested_atomic_model():
     inner_dynamic = Outer.model_fields["inner"].annotation
     inner_counter_type = inner_dynamic.model_fields["counter"].annotation
 
+    # Assert
     # Pre-condition — bare on every level.
-    assert _count_action_wrappers(vars(inner_counter_type)["asave"]) == 0
-
-    # Act — mutate ONLY Inner's Meta, then run recursive rebuild on Outer.
-    # The recursion should pick up the inner model and rebuild its field types
-    # against Inner's (now-TTLed) Meta, not Outer's.
-    Inner.Meta.ttl = 60
-    inner_dynamic.Meta.ttl = 60
-    recursive_build_redis_model(Outer)
-
-    # Assert — inner's per-field RedisInt got re-installed with TTL,
-    # picked up via Inner's Meta (Outer's Meta is still ttl=None).
-    assert Outer.Meta.ttl is None
     assert _count_action_wrappers(vars(inner_counter_type)["asave"]) == 1
 
-
-def test_plain_build_redis_model_on_child_does_not_touch_parent_field_install():
-    # Arrange — parent + child share a per-field type. Parent owns the field;
-    # child only differs in Meta. ``cls.build_redis_model()`` (the model-only
-    # rebuild) must not touch the shared field type — that's reserved for the
-    # opt-in ``recursive_build_redis_model`` test helper.
-    class OwnerModel(AtomicRedisModel):
-        Meta = RedisConfig(
-            ttl=60,
-            refresh_ttl=ActionGroup.UPDATE,
-            init_with_rapyer=False,
-        )
-        counter: int = 0
-
-    class HeirModel(OwnerModel):
-        Meta = RedisConfig(
-            ttl=60,
-            refresh_ttl=ActionGroup.READ,  # contradicts parent
-            init_with_rapyer=False,
-        )
-
-    field_type = OwnerModel.model_fields["counter"].annotation
-    assert HeirModel.model_fields["counter"].annotation is field_type
-
-    # Pre-condition — installed under parent's UPDATE meta.
-    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
-    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
-
-    # Act — child rebuilds via the model-only rebuild.
-    HeirModel.build_redis_model()
-
-    # Assert — parent's installation is untouched.
-    assert _count_action_wrappers(vars(field_type)["asave"]) == 1
-    assert _count_action_wrappers(vars(field_type)["aload"]) == 0
+    assert Outer.Meta.ttl is None
+    assert _count_action_wrappers(vars(inner_counter_type)["asave"]) == 1

--- a/tests/unit/mark_actions/test_target.py
+++ b/tests/unit/mark_actions/test_target.py
@@ -128,29 +128,6 @@ async def test_target_result_with_tuple_registers_each_item(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "value",
-    [None, "string-result", 42, {"a": 1}, b"bytes"],
-    ids=["none", "string", "int", "dict", "bytes"],
-)
-async def test_target_result_with_non_registerable_does_not_refresh(
-    setup_fake_redis, refresh_calls, value, mark_version
-):
-    # Arrange
-    @mark_actions(ActionGroup.READ, target=TargetSource.RESULT, version=mark_version)
-    async def make():
-        return value
-
-    make = maybe_install_v2(mark_version, make)
-
-    # Act
-    await make()
-
-    # Assert
-    assert refresh_calls == []
-
-
-@pytest.mark.asyncio
 async def test_target_result_mixed_list_only_registers_models(
     setup_fake_redis, refresh_calls, mark_version
 ):

--- a/tests/unit/mark_actions/test_target.py
+++ b/tests/unit/mark_actions/test_target.py
@@ -127,28 +127,6 @@ async def test_target_result_with_tuple_registers_each_item(
     assert {c.model.key for c in refresh_calls} == {a.key, b.key}
 
 
-@pytest.mark.asyncio
-async def test_target_result_mixed_list_only_registers_models(
-    setup_fake_redis, refresh_calls, mark_version
-):
-    # Arrange
-    a = TTLRefreshTestModel(name="mix-a")
-    b = TTLRefreshTestModel(name="mix-b")
-
-    @mark_actions(ActionGroup.UPDATE, target=TargetSource.RESULT, version=mark_version)
-    async def make_mixed():
-        return [a, "junk", 5, b, None]
-
-    make_mixed = maybe_install_v2(mark_version, make_mixed)
-
-    # Act
-    await make_mixed()
-
-    # Assert
-    refreshed_keys = {c.model.key for c in refresh_calls}
-    assert refreshed_keys == {a.key, b.key}
-
-
 # ---------- target=MANUAL ----------
 
 


### PR DESCRIPTION
## Summary

Migrates every `@mark_actions(...)` decorator on `BaseRedisType` subclasses (`dct`, `lst`, `string`, `byte`, `integer`, `float`, `datetime`, `priority_queue`, and `RedisType` itself) from v1 to `version="v2"`, so field-level Redis operations get the same decoration/install-time wrap-vs-no-wrap dispatch as `AtomicRedisModel` methods, removing per-call decorator overhead from the hottest paths in the library.

The main design wrinkle from #234 is resolved by installing per-field-class with the *owning model's* `Meta`: `RedisConverter` creates a fresh per-field subclass via `types.new_class` and threads `owner_meta` through `__init_subclass__`, where `install_marked_action_methods` runs against that meta. Static (module-load-time) subclasses keep their methods tagged but uninstalled — the dynamic per-field subclass installs them.

Closes #234

## Changes

- `rapyer/actions.py`
  - `install_marked_action_methods(cls, meta=None)` now takes an explicit meta; falls back to `cls.Meta` for the existing `AtomicRedisModel` path.
  - Added `ACTION_WRAPPER_SENTINEL` so re-installation only peels back wrappers we previously installed (e.g. parent-class install of the same method) and leaves other decorators like `marks_redis_updated` in place — needed so nested actions on field types preserve their full call chain on both wrap and no-wrap branches.
- `rapyer/types/base.py`
  - `BaseRedisType.__init_subclass__(*, owner_meta=None)` runs `install_marked_action_methods(cls, owner_meta)` when an owner meta is supplied. Without one, the subclass is treated as a static base and methods stay tagged for later install.
  - `RedisType.asave` / `RedisType.aload` switched to `version="v2"`.
- `rapyer/types/convert.py`
  - `RedisConverter._build_redis_subclass` builds per-field subclasses via `types.new_class`, passing `owner_meta` as a class-creation keyword so it reaches `__init_subclass__`.
- `rapyer/base.py`
  - `AtomicRedisModel.build_redis_model` passes `owner_meta=cls.Meta` into `RedisConverter` so each per-field subclass installs against the owning model's meta.
- `rapyer/types/{dct,lst,string,byte,integer,float,datetime,priority_queue}.py`
  - Every `@mark_actions(...)` switched to `version="v2"`.

## Testing

- Existing `tests/unit/mark_actions/` and per-type test suites should pass without modification (public behavior is unchanged: `ACTION_GROUPS_ATTR` still set, `ignore_refresh=True` still skips wrapping, outer-only flush, register-then-await ordering preserved).
- `marks_redis_updated`-stacked methods (e.g. `RedisStr.__iadd__`, `RedisFloat` arithmetic, `RedisDatetime` arithmetic) need to keep working — the wrapper sentinel ensures we don't peel that wrapper off when reinstalling.
- Run `benchmarks/test_list.py`, `benchmarks/test_priority_queue.py`, `benchmarks/test_no_redis_actions.py` before/after to confirm the field-level paths get the v2 speedup with no regression on model-level paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of stacked decorators so async-detection and rewrapping use the correct base function.

* **New Features**
  * Per-owner/config-aware type conversion and safe-load behavior.
  * Recursive model rebuild support for nested models.
  * TTL-mode benchmark variants and TTL-enabled/no‑TTL benchmark models.

* **Refactor**
  * Standardized action metadata to version "v2" across Redis-backed types.

* **Tests**
  * New unit tests and helpers covering wrapper install/peel logic and recursive rebuilds.

* **Chores**
  * CI workflow trigger updated to include an additional branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->