### PR TITLE
Fix afind/afind_one IndexError on missing keys under fakeredis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **TTL tracks nested special-field keys**: `refresh_ttl`, `refresh_ttl_if_needed`, and `aset_ttl` now expire every special-field key reachable from the model — including those on nested sub-models — instead of only top-level ones.
 - **TTL refresh resolves to the root model**: Actions triggered through a nested model or special field now walk back to the root aggregate that owns the Redis key and `Meta.ttl`, so TTL is refreshed on the correct key.
 - **Inherited special class field override**: Fixed a bug that caused a field to be classified as a special field even when it was overridden in a subclass
+- **`afind`/`afind_one` IndexError on missing keys under fakeredis**: `build_models_from_dumps` only checked for `None`, but fakeredis returns `[]` per missing `JSON.MGET` slot, raising `IndexError` instead of `KeyNotFound` (`afind` with explicit keys) or `None` (`afind_one`). The missing-key guard now matches the one in `aget`. (#245)
 
 ### 🛠️ Technical Improvements
 

--- a/rapyer/utils/redis.py
+++ b/rapyer/utils/redis.py
@@ -77,7 +77,8 @@ def build_models_from_dumps(
         slice_end = cursor + len(key_plan)
         raw_slice = sf_raw[cursor:slice_end]
         cursor = slice_end
-        if data is None:
+        # Real redis returns None for a missing key; fakeredis returns [].
+        if not data:
             if raise_on_missing:
                 raise KeyNotFound(f"{key} is missing in redis")
             continue

--- a/tests/unit/functioninality/test_rapyer_afind_with_fakeredis.py
+++ b/tests/unit/functioninality/test_rapyer_afind_with_fakeredis.py
@@ -2,6 +2,7 @@ import pytest
 
 import rapyer
 from tests.models.simple_types import IntModel, StrModel
+from tests.models.special_types import SubSubRedisSetModel
 
 
 @pytest.mark.asyncio
@@ -81,3 +82,16 @@ async def test_model_afind_with_key_without_prefix_with_fakeredis_sanity(
     # Assert
     assert len(result) == 1
     assert result[0].name == "test_name"
+
+
+@pytest.mark.asyncio
+async def test_sf_model_afind_one_with_missing_key_returns_none_with_fakeredis(
+    setup_fake_redis_for_models,
+    fake_redis_client,
+):
+    # Act - fakeredis returns [] (not None) per missing JSON.MGET slot; this
+    # used to raise IndexError instead of returning None
+    result = await SubSubRedisSetModel.afind_one("does-not-exist")
+
+    # Assert
+    assert result is None


### PR DESCRIPTION
## Summary

Fixes an `IndexError` raised by `afind()` / `afind_one()` when a requested key does not exist in Redis, when running against fakeredis. With explicit keys, `afind` now raises `KeyNotFound` and `afind_one` returns `None` — matching the behavior against real Redis.

## Changes

- `build_models_from_dumps` (`rapyer/utils/redis.py`): missing-key guard changed from `if data is None` to `if not data`. Real Redis `JSON.MGET` returns `None` per missing key, but fakeredis returns `[]`, which slipped past the `None` check and crashed on `data[0]`. The new guard mirrors the existing one in `aget`.
- Regression unit test: `afind_one` on a missing key with an SF-bearing model under fakeredis returns `None` instead of raising.
- CHANGELOG: fix entry added to the unreleased `[1.3.3]` section.

## Testing

- New test verified to fail with `IndexError` before the fix and pass after.
- Full `tests/unit` suite passes (690 tests, fakeredis).
- Full `tests/integration` suite passes against real Redis (1491 passed) — real Redis returns `[None]` per missing key, so behavior there is unchanged.

Closes #245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling when retrieving missing keys from Redis. Data retrieval operations with non-existent keys now complete successfully and return the expected default values instead of raising exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
