### PR TITLE
Stop using dynamic types in rapyer (#247)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,8 +23,7 @@ reviews:
         Check that pytest.mark.parametrize uses list-of-lists format.
     - path: "rapyer/**"
       instructions: |
-        Focus on correctness, error handling, and async safety.
-        Check that imports are at the top of the file following PEP 8 ordering.
+        Focus on correctness, error handling, async safety, and security issues.
 
   auto_review:
     enabled: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dependabot-updates"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -9,6 +10,7 @@ updates:
       - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dependabot-updates"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/redis-matrix.json
+++ b/.github/redis-matrix.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "CI redis test-matrix config. versions = full list; sample_per_branch = how many to randomly test per target branch (0 = all). Branches not listed fall back to 'default'.",
+  "versions": ["6.0", "6.1", "6.2", "6.3", "6.4", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"],
+  "sample_per_branch": {
+    "main": 0,
+    "develop": 3,
+    "default": 3
+  }
+}

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -33,7 +33,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with:

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   validate-branch-target:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
     - name: Validate PR target branch
@@ -38,11 +40,14 @@ jobs:
   mirror-redis:
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       packages: write
     outputs:
       image: ${{ steps.mirror.outputs.image }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - id: mirror
       uses: ./.github/actions/mirror-redis
       with:
@@ -52,11 +57,15 @@ jobs:
   # the branch maps to 0, otherwise a random sample of that branch's count.
   setup-matrix:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     needs: [validate-branch-target]
     outputs:
       redis-versions: ${{ steps.pick.outputs.redis }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - id: pick
       env:
         TARGET: ${{ github.base_ref || github.ref_name }}
@@ -70,9 +79,13 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target]
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -94,12 +107,16 @@ jobs:
   mypy:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target]
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -144,6 +161,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -182,6 +201,8 @@ jobs:
   test-results:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target, lint, mypy, test]
+    permissions:
+      contents: read
     if: always()
     steps:
       - name: Check test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,25 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Build the redis test matrix from .github/redis-matrix.json: all versions when
+  # the branch maps to 0, otherwise a random sample of that branch's count.
+  setup-matrix:
+    runs-on: ubuntu-22.04
+    needs: [validate-branch-target]
+    outputs:
+      redis-versions: ${{ steps.pick.outputs.redis }}
+    steps:
+    - uses: actions/checkout@v6
+    - id: pick
+      env:
+        TARGET: ${{ github.base_ref || github.ref_name }}
+      run: |
+        CFG=.github/redis-matrix.json
+        COUNT=$(jq -r --arg b "$TARGET" '.sample_per_branch[$b] // .sample_per_branch.default' "$CFG")
+        ALL=$(jq -r '.versions[]' "$CFG")
+        if [ "$COUNT" = "0" ]; then PICK="$ALL"; else PICK=$(shuf -n "$COUNT" <<< "$ALL"); fi
+        echo "redis=$(jq -R . <<< "$PICK" | jq -cs .)" >> "$GITHUB_OUTPUT"
+
   lint:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target]
@@ -98,8 +117,7 @@ jobs:
 
   test:
     runs-on: ubuntu-22.04
-    needs: [validate-branch-target, mirror-redis]
-    if: always() && (needs.validate-branch-target.result == 'success' || needs.validate-branch-target.result == 'skipped') && needs.mirror-redis.result == 'success'
+    needs: [validate-branch-target, mirror-redis, setup-matrix]
     permissions:
       contents: read
       packages: read
@@ -107,7 +125,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        redis-version: ["6.0", "6.1", "6.2", "6.3", "6.4", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
+        redis-version: ${{ fromJSON(needs.setup-matrix.outputs.redis-versions) }}
         pydantic-version: ["2.11", "2.12", "2.13"]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        redis-version: ["6.0", "6.1", "6.2", "6.3", "6.4", "7.0", "7.1", "7.2", "7.3", "7.4"]
+        redis-version: ["6.0", "6.1", "6.2", "6.3", "6.4", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
         pydantic-version: ["2.11", "2.12", "2.13"]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     outputs:
       image: ${{ steps.mirror.outputs.image }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - id: mirror
       uses: ./.github/actions/mirror-redis
       with:
@@ -55,7 +55,7 @@ jobs:
     if: always() && (needs.validate-branch-target.result == 'success' || needs.validate-branch-target.result == 'skipped')
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -83,7 +83,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -128,7 +128,7 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   validate-branch-target:
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
 
     steps:
     - name: Validate PR target branch
@@ -23,7 +22,7 @@ jobs:
       run: |
         echo "Source branch: $SOURCE_BRANCH"
         echo "Target branch: $TARGET_BRANCH"
-        
+
         # Rule 1: Only develop branch can merge to main
         if [[ "$TARGET_BRANCH" == "main" && "$SOURCE_BRANCH" != "develop" ]]; then
           echo "❌ Error: Only 'develop' branch can merge to 'main'"
@@ -52,7 +51,6 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target]
-    if: always() && (needs.validate-branch-target.result == 'success' || needs.validate-branch-target.result == 'skipped')
 
     steps:
     - uses: actions/checkout@v6
@@ -77,7 +75,6 @@ jobs:
   mypy:
     runs-on: ubuntu-22.04
     needs: [validate-branch-target]
-    if: always() && (needs.validate-branch-target.result == 'success' || needs.validate-branch-target.result == 'skipped')
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       image: ${{ steps.mirror.outputs.image }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - id: mirror
       uses: ./.github/actions/mirror-redis
       with:
@@ -50,7 +50,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -104,7 +104,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,14 @@ jobs:
   mirror-redis:
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       packages: write
     outputs:
       image: ${{ steps.mirror.outputs.image }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - id: mirror
       uses: ./.github/actions/mirror-redis
       with:
@@ -51,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -105,6 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,7 +53,7 @@ jobs:
         run: python .github/scripts/generate_roadmap.py
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
         
@@ -61,7 +61,7 @@ jobs:
         run: mkdocs build
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
         
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pm.yml
+++ b/.github/workflows/pm.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract issue number from branch name and close
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const branchName = context.payload.pull_request.head.ref;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history for tagging
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Need full history for tag lookup
+        persist-credentials: false
 
     - name: Get latest v* tag
       id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write  # Required for creating releases
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Need full history for tag lookup
 
@@ -70,7 +70,7 @@ jobs:
         } >> $GITHUB_OUTPUT
     
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -50,12 +50,12 @@ jobs:
       name: security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,6 +55,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v3

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       # Checkout project source
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # Scan code tokenless with the auto ruleset, emitting a SARIF report.
       # Exclude the Python 3.7 importlib compat rule: this project targets

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,7 +39,7 @@ jobs:
       image: semgrep/semgrep
     steps:
       # Checkout project source
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Scan code tokenless with the auto ruleset, emitting a SARIF report.
       # Exclude the Python 3.7 importlib compat rule: this project targets

--- a/.github/workflows/speed.yml
+++ b/.github/workflows/speed.yml
@@ -29,6 +29,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Set up Python

--- a/.github/workflows/speed.yml
+++ b/.github/workflows/speed.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.3.4]
+
+### 🔄 Changed
+
+- **No runtime dynamic classes for typed fields**: rapyer no longer builds per-field dynamic subclasses of its redis types and references when a model is defined. It reuses the static generic classes (`RedisList[str]`, `RedisDict`, `Reference[T]`, …) and recovers the inner element type from the generic parameterization instead. Per-field state that used to be baked into those generated classes — `field_name` and `original_type` — is now stored per-instance or derived on demand. Existing models behave the same. (#247)
+- **Generic origin models are skipped during initialization**: a generic origin declared as `class M(AtomicRedisModel, Generic[T])` (with unbound type parameters) is no longer registered or initialized by `init_rapyer`. Register and use a concrete parametrization (e.g. `class StrM(M[str])`) instead — see the *Generic Models* note in the initialization docs. This prevents the query-expression attributes installed at init from shadowing the field defaults of parametrizations built afterwards.
+- **`afetch` no longer triggers its own TTL refresh**: resolving a reference with `await ref.afetch()` reads the target through its own `aget`, so the referenced model's TTL is refreshed only when that model's settings refresh on read/fetch — the owner's key is never touched.
+
+### 🛠️ Technical Improvements
+
+- **Wider redis range**: supported redis range widened to `redis>=6.0.0,<8.1.0`.
+
+
 ## [1.3.3]
 
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### 🐛 Fixed
 
-- **Special fields are excluded from `model_dump`**: special-field types (`RedisPriorityQueue`, `RedisSet`, …) live in their own Redis keys and are never part of the model's JSON document, but only `redis_dump`/`redis_dump_json` excluded them. A plain `model_dump()` left them in — `model_dump(mode="json")` even raised `PydanticSerializationError: Unable to serialize unknown type` on the queue proxy. Special fields are now marked pydantic-excluded when the model class is built, so every dump path (`model_dump`, `model_dump_json`, `redis_dump`) omits them — the exclusion composes through nested models too.
+- **`aduplicate` no longer re-serializes per copy**: `aduplicate_many` dumped the source model once *per* duplicate. The dump is now taken a single time and reused across all copies (re-validation per copy is still what rebinds each duplicate's special fields to its own key).
+
+### 📝 Documentation
+
+- **`RedisPriorityQueue` fields must be declared with `Field(exclude=True)`**: a priority queue is a pure server-side proxy with no local data, so it has no place in the model's JSON document. Without `exclude=True`, `model_dump(mode="json")` raises when serializing the queue. This is now documented as required on the Priority Queue page. (`RedisSet`, which holds real local members, serializes normally and does not need this.)
 
 ### 🛠️ Technical Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **Generic origin models are skipped during initialization**: a generic origin declared as `class M(AtomicRedisModel, Generic[T])` (with unbound type parameters) is no longer registered or initialized by `init_rapyer`. Register and use a concrete parametrization (e.g. `class StrM(M[str])`) instead — see the *Generic Models* note in the initialization docs. This prevents the query-expression attributes installed at init from shadowing the field defaults of parametrizations built afterwards.
 - **`afetch` no longer triggers its own TTL refresh**: resolving a reference with `await ref.afetch()` reads the target through its own `aget`, so the referenced model's TTL is refreshed only when that model's settings refresh on read/fetch — the owner's key is never touched.
 
+### 🐛 Fixed
+
+- **Special fields are excluded from `model_dump`**: special-field types (`RedisPriorityQueue`, `RedisSet`, …) live in their own Redis keys and are never part of the model's JSON document, but only `redis_dump`/`redis_dump_json` excluded them. A plain `model_dump()` left them in — `model_dump(mode="json")` even raised `PydanticSerializationError: Unable to serialize unknown type` on the queue proxy. Special fields are now marked pydantic-excluded when the model class is built, so every dump path (`model_dump`, `model_dump_json`, `redis_dump`) omits them — the exclusion composes through nested models too.
+
 ### 🛠️ Technical Improvements
 
 - **Wider redis range**: supported redis range widened to `redis>=6.0.0,<8.1.0`.

--- a/docs/documentation/initialization.md
+++ b/docs/documentation/initialization.md
@@ -78,6 +78,34 @@ await init_rapyer(redis=redis_client, ttl=3600)
 **Important:** `init_rapyer` is crucial for initializing special fields like indexed fields and other advanced features.
 For simple usage, it is possible to simply set the redis client yourself.
 
+## Generic Models
+
+!!! warning "Generic origin models are skipped during initialization"
+    A **generic origin** — declared as
+    `class MyModel(AtomicRedisModel, Generic[T])` with unbound type
+    parameters — is automatically left out of `init_rapyer`. Register and use a
+    concrete parametrization instead:
+
+    ```python
+    T = TypeVar("T")
+
+    class Event(AtomicRedisModel, Generic[T]):  # origin: auto-skipped
+        payload: T
+
+    class StrEvent(Event[str]):
+        ...  # concrete subclass — registered, initialized, queryable
+    ```
+
+??? note "Why generic origins are skipped (mechanics)"
+    The query API exposes each field as a class attribute (so `User.age > 18`
+    works), and `init_rapyer` installs those attributes. Pydantic treats a
+    class attribute that matches a field name as that field's **default**, so on
+    a generic origin the installed attribute would shadow the real default —
+    and any concrete parametrization (`MyModel[str]`) built *afterwards* would
+    inherit that shadowed default and fail to construct. Rapyer avoids this by
+    not registering origins with unbound type parameters; their concrete
+    parametrizations are registered normally.
+
 ## teardown_rapyer Function
 
 The `teardown_rapyer` function properly closes Redis connections for all models, ensuring clean resource cleanup.

--- a/docs/documentation/initialization.md
+++ b/docs/documentation/initialization.md
@@ -86,6 +86,7 @@ For simple usage, it is possible to simply set the redis client yourself.
     parameters — is automatically left out of `init_rapyer`. Register and use a
     concrete parametrization instead:
 
+    <!-- markdownlint-disable-next-line MD046 -->
     ```python
     T = TypeVar("T")
 

--- a/docs/documentation/special-fields/priority-queue.md
+++ b/docs/documentation/special-fields/priority-queue.md
@@ -9,6 +9,12 @@
 
 Unlike regular Redis types (`RedisStr`, `RedisList`, etc.), the priority queue stores its data in a **separate Redis key** — not inline with the model's JSON. This means it operates as a pure Redis proxy with no local state.
 
+!!! warning "Always declare priority queue fields with `exclude=True`"
+    A priority queue isn't a real field on your model — its data lives only on the
+    server (Redis), never inside the model itself. So you must mark it with
+    `Field(..., exclude=True)`. Without it, dumping the model (e.g.
+    `model_dump(mode="json")`) will raise an error.
+
 ```python
 from pydantic import Field
 from rapyer import AtomicRedisModel
@@ -17,7 +23,7 @@ from rapyer.types import RedisPriorityQueue
 
 class JobQueue(AtomicRedisModel):
     name: str = "default"
-    tasks: RedisPriorityQueue[str] = Field(default_factory=RedisPriorityQueue)
+    tasks: RedisPriorityQueue[str] = Field(default_factory=RedisPriorityQueue, exclude=True)
 ```
 
 ## Basic Usage
@@ -44,10 +50,12 @@ task = await queue.tasks.apop()  # None (empty)
 
 ```python
 class IntQueue(AtomicRedisModel):
-    scores: RedisPriorityQueue[int] = Field(default_factory=RedisPriorityQueue)
+    scores: RedisPriorityQueue[int] = Field(default_factory=RedisPriorityQueue, exclude=True)
 
 class FloatQueue(AtomicRedisModel):
-    measurements: RedisPriorityQueue[float] = Field(default_factory=RedisPriorityQueue)
+    measurements: RedisPriorityQueue[float] = Field(
+        default_factory=RedisPriorityQueue, exclude=True
+    )
 ```
 
 ## Operations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
     "pytest-asyncio>=0.25.0",
     "pytest-cov>=6.0.0",
     "fakeredis[lua,json]>=2.20.0",
+    "tox>=4.55.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapyer"
-version = "1.3.3"
+version = "1.3.4"
 description = "Pydantic models with Redis as the backend"
 authors = [{name = "YedidyaHKfir", email = "yedidyakfir@gmail.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "redis>=6.0.0, <7.5.0",
+    "redis>=6.0.0, <8.1.0",
     "pydantic>=2.11.0, <2.14.0",
 ]
 

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -440,8 +440,14 @@ class AtomicRedisModel(BaseModel):
         cls.build_redis_model()
 
         # Update the redis model list for initialization
-        # Skip dynamically created classes from type conversion
-        if cls.__doc__ != DYNAMIC_CLASS_DOC and cls.Meta.init_with_rapyer:
+        # Skip dynamically created classes from type conversion.
+        # Skip generic origins
+        not_generic_origin = not bool(getattr(cls, "__parameters__", ()))
+        if (
+            cls.__doc__ != DYNAMIC_CLASS_DOC
+            and cls.Meta.init_with_rapyer
+            and not_generic_origin
+        ):
             existing = next(
                 (m for m in REDIS_MODELS if m.__name__ == cls.__name__), None
             )

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -1033,6 +1033,11 @@ class AtomicRedisModel(BaseModel):
             yield redis_model
 
     def __setattr__(self, name: str, value: Any) -> None:
+        # Dont change private attr set beahvior
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+            return
+
         skip_redis_set = False
         if isinstance(value, BaseRedisType):
             skip_redis_set = value._redis_updated
@@ -1044,7 +1049,7 @@ class AtomicRedisModel(BaseModel):
 
         if value is not None:
             attr = getattr(self, name)
-            if isinstance(attr, BaseRedisType):
+            if isinstance(attr, (BaseRedisType, AtomicRedisModel)):
                 attr._base_model_link = self
                 attr.field_name = f".{name}"
 

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -83,6 +83,7 @@ from rapyer.types.special import SpecialFieldType
 from rapyer.typing_support import Self, Unpack
 from rapyer.utils.annotation import (
     DYNAMIC_CLASS_DOC,
+    annotation_origin,
     field_with_flag,
     has_annotation,
     replace_to_redis_types_in_annotation,
@@ -343,11 +344,14 @@ class AtomicRedisModel(BaseModel):
         original_annotations = cls.__annotations__.copy()
         original_annotations.update(new_annotation)
 
-        def _check_is_excluded(name_of_field: str) -> bool:
+        def _check_is_excluded(name_of_field: str, annot) -> bool:
             info = pydantic_annotation.get(name_of_field) or cls.__dict__.get(
                 name_of_field
             )
-            return isinstance(info, FieldInfo) and info.exclude is True
+            if not (isinstance(info, FieldInfo) and info.exclude is True):
+                return False
+            # Redis types are converted even if exlcuded
+            return not safe_issubclass(annotation_origin(annot), BaseRedisType)
 
         new_annotations = {
             field_name: replace_to_redis_types_in_annotation(
@@ -362,7 +366,7 @@ class AtomicRedisModel(BaseModel):
             )
             for field_name, annotation in original_annotations.items()
             if is_redis_field(field_name, annotation)
-            if not _check_is_excluded(field_name)
+            if not _check_is_excluded(field_name, annotation)
         }
         cls.__annotations__ = {**cls.__annotations__, **new_annotations}
         for field_name, field in pydantic_annotation.items():

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -626,6 +626,7 @@ class AtomicRedisModel(BaseModel):
         instance = cls.model_validate(model_dump, context=context)
         instance._pk = self._pk
         instance._base_model_link = self._base_model_link
+        instance.field_name = self.field_name
         instance._failed_fields = context.get(FAILED_FIELDS_KEY, set())
         return instance
 
@@ -654,12 +655,14 @@ class AtomicRedisModel(BaseModel):
 
     @classmethod
     def queue_special_loads_in_pipeline(
-        cls, pipe, key: str, plan: list, parent_path: str = ""
+        cls, pipe, key: str, plan: list, parent_path: str = "", field_name: str = ""
     ):
         """Queue load ops for every SF reachable from this model. both directly and nested (in a list or container model)"""
         for fname in cls._special_field_names:
             field_cls = cls.model_fields[fname].annotation
-            field_cls.queue_special_loads_in_pipeline(pipe, key, plan, parent_path)
+            field_cls.queue_special_loads_in_pipeline(
+                pipe, key, plan, parent_path, field_name=f".{fname}"
+            )
         for fname in cls._contain_sf:
             field_cls = cls.model_fields[fname].annotation
             nested_path = f"{parent_path}.{fname}"
@@ -1027,6 +1030,7 @@ class AtomicRedisModel(BaseModel):
             attr = getattr(self, name)
             if isinstance(attr, BaseRedisType):
                 attr._base_model_link = self
+                attr.field_name = f".{name}"
 
         if skip_redis_set:
             return
@@ -1071,6 +1075,7 @@ class AtomicRedisModel(BaseModel):
             attr = instance_dict.get(name)
             if attr is not None:
                 attr._base_model_link = self
+                attr.field_name = f".{name}"
         return self
 
 

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -77,6 +77,7 @@ from rapyer.types.base import (
     RedisType,
 )
 from rapyer.types.convert import RedisConverter
+from rapyer.types.generic import GenericRedisType
 from rapyer.types.relational import RelationalFieldType
 from rapyer.types.special import SpecialFieldType
 from rapyer.typing_support import Self, Unpack
@@ -248,7 +249,12 @@ class AtomicRedisModel(BaseModel):
         for field_name, field_info in cls.model_fields.items():
             real_type = field_info.annotation
             # Check if real_type is a class before using issubclass
-            if get_origin(real_type) is not None or not isinstance(real_type, type):
+            if (
+                get_origin(real_type) is not None
+                or not isinstance(real_type, type)
+                or safe_issubclass(real_type, GenericRedisType)
+                or safe_issubclass(real_type, SpecialFieldType)
+            ):
                 if field_with_flag(field_info, IndexAnnotation):
                     raise UnsupportedIndexedFieldError(
                         f"Field {field_name} is type {real_type}, and not supported for indexing"

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -413,6 +413,10 @@ class AtomicRedisModel(BaseModel):
             # Skip special fields — they handle their own serialization
             if attr_name in cls._special_field_names:
                 continue
+            # Skip relational fields — ForeignKey is left unconverted and
+            # serializes itself to a key string via its own core schema.
+            if attr_name in cls._relational_field_names:
+                continue
             if original_annotations[attr_name] == attr_type:
                 default_value = cls.__dict__.get(attr_name, None)
                 can_json = is_type_json_serializable(attr_type, default_value)

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -519,7 +519,8 @@ class AtomicRedisModel(BaseModel):
         if self.is_inner_model():
             raise RuntimeError("Can only duplicate from top level model")
 
-        duplicated_models = [self.__class__(**self.model_dump()) for _ in range(num)]
+        dump = self.model_dump()
+        duplicated_models = [self.__class__(**dump) for _ in range(num)]
         async with ensure_pipeline(self.Meta) as pipe:
             for dup in duplicated_models:
                 pipe.copy(self.key, dup.key)

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -384,6 +384,7 @@ class AtomicRedisModel(BaseModel):
         cls._contain_fk = set(getattr(cls, "_contain_fk", set()))
         for field_name, annotation in cls.__annotations__.items():
             # If the field was redfined, we remove it from list
+            cls._redis_link_field_names.discard(field_name)
             cls._special_field_names.discard(field_name)
             cls._contain_sf.discard(field_name)
             cls._relational_field_names.discard(field_name)
@@ -1102,7 +1103,7 @@ class AtomicRedisModel(BaseModel):
         instance_dict = self.__dict__
         for name in link_fields:
             attr = instance_dict.get(name)
-            if attr is not None:
+            if isinstance(attr, (BaseRedisType, AtomicRedisModel)):
                 attr._base_model_link = self
                 attr.field_name = f".{name}"
 

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -1081,18 +1081,20 @@ class AtomicRedisModel(BaseModel):
             return values.model_dump()
         return values
 
-    @model_validator(mode="after")
-    def assign_fields_links(self):
+    def model_post_init(self, __context: Any) -> None:
+        # Wire child redis types / nested models back to this model once, after
+        # construction or full validation. validate_assignment does NOT call this,
+        # so per-field reassignment is handled in __setattr__ instead — keeping
+        # repeated assignments from re-linking every sibling field every time.
         link_fields = self.__class__._redis_link_field_names
         if not link_fields:
-            return self
+            return
         instance_dict = self.__dict__
         for name in link_fields:
             attr = instance_dict.get(name)
             if attr is not None:
                 attr._base_model_link = self
                 attr.field_name = f".{name}"
-        return self
 
 
 REDIS_MODELS: list[type[AtomicRedisModel]] = []

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -2,7 +2,7 @@ import abc
 import base64
 import pickle
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import core_schema
@@ -26,18 +26,8 @@ class BaseRedisType(ABC):
     _adapter: TypeAdapter = None
     field_name: str
 
-    @classmethod
-    def wrapped_python_type(cls) -> type:
-        """The plain Python type this redis type wraps (e.g. ``int``, ``str``, ``list``).
-
-        Recovered from the MRO — the first base that is not one of rapyer's own
-        redis types — so it needs no stored attribute and stays correct for
-        subclasses (e.g. ``RedisDatetimeTimestamp`` -> ``datetime``).
-        """
-        for base in cls.__mro__:
-            if base is not object and not issubclass(base, BaseRedisType):
-                return base
-        return object
+    # The plain Python type this redis type wraps (e.g. ``int``, ``str``, ``list``).
+    wrapped_python_type: ClassVar[type]
 
     def __init_subclass__(cls, *, owner_meta: Optional["RedisConfig"] = None, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -164,7 +154,7 @@ class RedisType(BaseRedisType):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_after_validator_function(
-            cls, handler(cls.wrapped_python_type())
+            cls, handler(cls.wrapped_python_type)
         )
 
     @staticmethod

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -23,9 +23,21 @@ FAILED_FIELDS_KEY = "__rapyer_failed_fields__"
 class BaseRedisType(ABC):
     """Common base for all Redis-aware field types (inline and special)."""
 
-    original_type: type = None
     _adapter: TypeAdapter = None
     field_name: str
+
+    @classmethod
+    def wrapped_python_type(cls) -> type:
+        """The plain Python type this redis type wraps (e.g. ``int``, ``str``, ``list``).
+
+        Recovered from the MRO — the first base that is not one of rapyer's own
+        redis types — so it needs no stored attribute and stays correct for
+        subclasses (e.g. ``RedisDatetimeTimestamp`` -> ``datetime``).
+        """
+        for base in cls.__mro__:
+            if base is not object and not issubclass(base, BaseRedisType):
+                return base
+        return object
 
     def __init_subclass__(cls, *, owner_meta: Optional["RedisConfig"] = None, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -152,7 +164,7 @@ class RedisType(BaseRedisType):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_after_validator_function(
-            cls, handler(cls.original_type)
+            cls, handler(cls.wrapped_python_type())
         )
 
     @staticmethod

--- a/rapyer/types/base.py
+++ b/rapyer/types/base.py
@@ -24,8 +24,8 @@ class BaseRedisType(ABC):
     """Common base for all Redis-aware field types (inline and special)."""
 
     original_type: type = None
-    field_name: str = None
     _adapter: TypeAdapter = None
+    field_name: str
 
     def __init_subclass__(cls, *, owner_meta: Optional["RedisConfig"] = None, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -60,7 +60,7 @@ class BaseRedisType(ABC):
 
     @classmethod
     def queue_special_loads_in_pipeline(
-        cls, pipe, key: str, plan: list, parent_path: str = ""
+        cls, pipe, key: str, plan: list, parent_path: str = "", field_name: str = ""
     ):
         """Queue any special-field loads this type contributes into ``pipe``., it will be used by the pipe creator"""
         return
@@ -105,6 +105,7 @@ class BaseRedisType(ABC):
     def __init__(self, *args, **kwargs):
         self._base_model_link = None
         self._redis_updated = False
+        self.field_name = ""
 
     def init_redis_field(self, key, val):
         if hasattr(val, "_base_model_link"):

--- a/rapyer/types/byte.py
+++ b/rapyer/types/byte.py
@@ -8,8 +8,6 @@ from rapyer.types.base import REDIS_DUMP_FLAG_NAME, RedisType
 
 
 class RedisBytes(bytes, RedisType):
-    original_type = bytes
-
     def clone(self):
         return bytes(self)
 
@@ -28,7 +26,7 @@ class RedisBytes(bytes, RedisType):
         return core_schema.no_info_after_validator_function(
             cls,
             core_schema.with_info_before_validator_function(
-                cls._validate_pickle, handler(cls.original_type)
+                cls._validate_pickle, handler(bytes)
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 cls._serialize_pickle,

--- a/rapyer/types/convert.py
+++ b/rapyer/types/convert.py
@@ -25,11 +25,16 @@ class RedisConverter(TypeConverter):
         self.safe_load = safe_load
         self.owner_meta = owner_meta
 
-    def _build_redis_subclass(self, name: str, base: type, namespace: dict) -> type:
+    def _build_redis_subclass(
+        self, name: str, base: type, namespace: dict, generic_values=None
+    ) -> type:
         """Create a per-field BaseRedisType subclass and pass owner_meta into __init_subclass__."""
         kwds = {"owner_meta": self.owner_meta} if self.owner_meta is not None else {}
-        params = getattr(base, "__parameters__", None)
-        gen_base = base[params] if params else base
+        if generic_values is not None:
+            gen_base = base[generic_values]
+        else:
+            params = getattr(base, "__parameters__", None)
+            gen_base = base[params] if params else base
         return _python_types.new_class(
             name,
             bases=(gen_base,),
@@ -72,16 +77,13 @@ class RedisConverter(TypeConverter):
             )
         if safe_issubclass(type_to_convert, BaseRedisType):
             redis_type = type_to_convert
-            original_type = type_to_convert.original_type
         else:
             redis_type = self.supported_types[type_to_convert]
-            original_type = type_to_convert
 
         new_type = self._build_redis_subclass(
             redis_type.__name__,
             redis_type,
             dict(
-                original_type=original_type,
                 safe_load=self.safe_load,
                 __doc__=DYNAMIC_CLASS_DOC,
             ),
@@ -95,23 +97,18 @@ class RedisConverter(TypeConverter):
     ) -> type:
         if safe_issubclass(type_to_covert, BaseRedisType):
             redis_type = type_to_covert
-            original_type = type_to_covert.original_type
         else:
             redis_type = self.supported_types[type_to_covert]
-            original_type = type_to_covert
-            original_type = original_type[generic_values]
 
         new_type = self._build_redis_subclass(
             redis_type.__name__,
             redis_type,
             dict(
-                original_type=original_type,
                 safe_load=self.safe_load,
                 __doc__=DYNAMIC_CLASS_DOC,
             ),
+            generic_values=generic_values,
         )
 
-        adapter_type = new_type[generic_values]
-        if issubclass(redis_type, BaseRedisType):
-            new_type._adapter = TypeAdapter(adapter_type)
-        return new_type[generic_values]
+        new_type._adapter = TypeAdapter(new_type)
+        return new_type

--- a/rapyer/types/convert.py
+++ b/rapyer/types/convert.py
@@ -1,7 +1,7 @@
 import types as _python_types
 from typing import TYPE_CHECKING, Optional, get_origin
 
-from pydantic import BaseModel, PrivateAttr, TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 from rapyer.fields.key import RapyerKey
 from rapyer.types.base import BaseRedisType
@@ -61,20 +61,14 @@ class RedisConverter(TypeConverter):
             return type(
                 type_to_convert.__name__,
                 (type_to_convert,),
-                dict(
-                    _field_name=PrivateAttr(default=self.field_name),
-                    __doc__=DYNAMIC_CLASS_DOC,
-                ),
+                dict(__doc__=DYNAMIC_CLASS_DOC),
             )
         if safe_issubclass(type_to_convert, BaseModel):
             origin: type[BaseModel]
             return type(
                 f"Redis{type_to_convert.__name__}",
                 (AtomicRedisModel, type_to_convert),
-                dict(
-                    _field_name=PrivateAttr(default=self.field_name),
-                    __doc__=DYNAMIC_CLASS_DOC,
-                ),
+                dict(__doc__=DYNAMIC_CLASS_DOC),
             )
         if safe_issubclass(type_to_convert, BaseRedisType):
             redis_type = type_to_convert
@@ -87,7 +81,6 @@ class RedisConverter(TypeConverter):
             redis_type.__name__,
             redis_type,
             dict(
-                field_name=self.field_name,
                 original_type=original_type,
                 safe_load=self.safe_load,
                 __doc__=DYNAMIC_CLASS_DOC,
@@ -112,7 +105,6 @@ class RedisConverter(TypeConverter):
             redis_type.__name__,
             redis_type,
             dict(
-                field_name=self.field_name,
                 original_type=original_type,
                 safe_load=self.safe_load,
                 __doc__=DYNAMIC_CLASS_DOC,

--- a/rapyer/types/datetime.py
+++ b/rapyer/types/datetime.py
@@ -11,8 +11,6 @@ from rapyer.types.base import REDIS_DUMP_FLAG_NAME, RedisType
 
 
 class RedisDatetime(datetime, RedisType):
-    original_type = datetime
-
     def __new__(cls, value, *args, **kwargs):
         if isinstance(value, datetime):
             # Support init from a datetime, preserving microseconds and timezone
@@ -77,7 +75,7 @@ class RedisDatetimeTimestamp(RedisDatetime):
         return core_schema.no_info_after_validator_function(
             cls,
             core_schema.with_info_before_validator_function(
-                cls._validate_timestamp, handler(cls.original_type)
+                cls._validate_timestamp, handler(datetime)
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 cls._serialize_timestamp,

--- a/rapyer/types/datetime.py
+++ b/rapyer/types/datetime.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from pydantic_core import core_schema
 from pydantic_core.core_schema import SerializationInfo, ValidationInfo
@@ -11,6 +11,8 @@ from rapyer.types.base import REDIS_DUMP_FLAG_NAME, RedisType
 
 
 class RedisDatetime(datetime, RedisType):
+    wrapped_python_type: ClassVar[type] = datetime
+
     def __new__(cls, value, *args, **kwargs):
         if isinstance(value, datetime):
             # Support init from a datetime, preserving microseconds and timezone

--- a/rapyer/types/dct.py
+++ b/rapyer/types/dct.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeAlias, TypeVar
 
 from pydantic_core import core_schema
 
@@ -13,6 +13,8 @@ T = TypeVar("T")
 
 
 class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
+    wrapped_python_type: ClassVar[type] = dict
+
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         GenericRedisType.__init__(self, *args, **kwargs)

--- a/rapyer/types/dct.py
+++ b/rapyer/types/dct.py
@@ -13,8 +13,6 @@ T = TypeVar("T")
 
 
 class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
-    original_type = dict
-
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         GenericRedisType.__init__(self, *args, **kwargs)

--- a/rapyer/types/dct.py
+++ b/rapyer/types/dct.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, get_args
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
 
 from pydantic_core import core_schema
 
@@ -6,6 +6,7 @@ from rapyer.actions import ActionGroup, mark_actions
 from rapyer.scripts import DICT_POP_SCRIPT_NAME, DICT_POPITEM_SCRIPT_NAME, arun_sha
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME, RedisType
 from rapyer.types.generic import SKIP_SENTINEL, GenericRedisType
+from rapyer.utils.pythonic import resolve_generic_args
 from rapyer.utils.redis import update_keys_in_pipeline
 
 T = TypeVar("T")
@@ -20,7 +21,7 @@ class RedisDict(dict[str, T], GenericRedisType, Generic[T]):
 
     @classmethod
     def find_inner_type(cls, type_):
-        args = get_args(type_)
+        args = resolve_generic_args(type_)
         if len(args) >= 2:
             return args[1]
         elif args:

--- a/rapyer/types/float.py
+++ b/rapyer/types/float.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from redis.commands.search.field import NumericField
 
@@ -15,6 +15,8 @@ from rapyer.types.base import RedisType
 
 
 class RedisFloat(float, RedisType):
+    wrapped_python_type: ClassVar[type] = float
+
     @classmethod
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)

--- a/rapyer/types/float.py
+++ b/rapyer/types/float.py
@@ -15,8 +15,6 @@ from rapyer.types.base import RedisType
 
 
 class RedisFloat(float, RedisType):
-    original_type = float
-
     @classmethod
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)

--- a/rapyer/types/foreign_key.py
+++ b/rapyer/types/foreign_key.py
@@ -57,7 +57,6 @@ class ForeignKey(RelationalFieldType, Generic[T]):
             )
         return self._value
 
-    @mark_actions(ActionGroup.READ, ActionGroup.FETCH, target=TargetSource.RESULT)
     async def afetch(self) -> "AtomicRedisModel":
         """Resolve the target instance from Redis and cache it in-place."""
         if self._value is not None:

--- a/rapyer/types/foreign_key.py
+++ b/rapyer/types/foreign_key.py
@@ -20,8 +20,6 @@ class ForeignKey(RelationalFieldType, Generic[T]):
     (e.g. ``"Author:abc-123"``). Construct from any of:
     """
 
-    original_type: type = str
-
     def __init__(self, ref: "str | AtomicRedisModel"):
         super().__init__()
         if isinstance(ref, str):

--- a/rapyer/types/foreign_key.py
+++ b/rapyer/types/foreign_key.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, get_args
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -88,6 +88,7 @@ class ForeignKey(RelationalFieldType, Generic[T]):
             )
         return getattr(value, name)
 
+    # TODO - support for atmoic model comparison
     def __eq__(self, other: object) -> bool:
         if isinstance(other, ForeignKey):
             return self._target_key == other._target_key
@@ -104,30 +105,24 @@ class ForeignKey(RelationalFieldType, Generic[T]):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        args = get_args(source_type)
-        target = args[0] if args else None
-
+        # We validate with the Foriegn key with generic
         def _validate(value: Any) -> "ForeignKey":
             from rapyer.base import AtomicRedisModel
 
-            fk: "ForeignKey | None" = None
             if isinstance(value, ForeignKey):
-                fk = value
-            elif isinstance(value, (AtomicRedisModel, str)):
+                return value
+            if isinstance(value, (AtomicRedisModel, str)):
                 # __init__ dispatches: a str is a key, a model is the target.
-                fk = cls(value)
-            elif isinstance(value, dict):
+                return source_type(value)
+            if isinstance(value, dict):
                 # Beanie-style DBRef: {"$ref": "Author", "$id": "abc-123"}
                 ref = value.get("$ref")
                 pk = value.get("$id")
                 if ref is not None and pk is not None:
-                    fk = cls(f"{ref}:{pk}")
-            if fk is None:
-                raise TypeError(
-                    f"Cannot validate ForeignKey from {type(value).__name__}: {value!r}"
-                )
-            fk._relational_target = target
-            return fk
+                    return source_type(f"{ref}:{pk}")
+            raise TypeError(
+                f"Cannot validate ForeignKey from {type(value).__name__}: {value!r}"
+            )
 
         def _serialize(value: "ForeignKey") -> str | None:
             if value is None:

--- a/rapyer/types/foreign_key.py
+++ b/rapyer/types/foreign_key.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, get_args
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
-from rapyer.actions import ActionGroup, TargetSource, mark_actions
 from rapyer.errors import NotResolvedError
 from rapyer.types.relational import RelationalFieldType
 
@@ -22,7 +21,6 @@ class ForeignKey(RelationalFieldType, Generic[T]):
     """
 
     original_type: type = str
-    _target_type_hint: Any = None
 
     def __init__(self, ref: "str | AtomicRedisModel"):
         super().__init__()
@@ -34,11 +32,6 @@ class ForeignKey(RelationalFieldType, Generic[T]):
             # Anything else is assumed to be the target AtomicRedisModel.
             self._value = ref
             self._target_key = ref.key
-
-    def __class_getitem__(cls, item):
-        parameterized = super().__class_getitem__(item)
-        parameterized._target_type_hint = item
-        return parameterized
 
     @property
     def target_key(self) -> str | None:
@@ -112,37 +105,34 @@ class ForeignKey(RelationalFieldType, Generic[T]):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         args = get_args(source_type)
-        target_hint = args[0] if args else cls._target_type_hint
+        target = args[0] if args else None
 
         def _validate(value: Any) -> "ForeignKey":
             from rapyer.base import AtomicRedisModel
 
+            fk: "ForeignKey | None" = None
             if isinstance(value, ForeignKey):
-                return value
-            if isinstance(value, (AtomicRedisModel, str)):
+                fk = value
+            elif isinstance(value, (AtomicRedisModel, str)):
                 # __init__ dispatches: a str is a key, a model is the target.
-                return cls(value)
-            if isinstance(value, dict):
+                fk = cls(value)
+            elif isinstance(value, dict):
                 # Beanie-style DBRef: {"$ref": "Author", "$id": "abc-123"}
                 ref = value.get("$ref")
                 pk = value.get("$id")
                 if ref is not None and pk is not None:
-                    return cls(f"{ref}:{pk}")
-            raise TypeError(
-                f"Cannot validate ForeignKey from {type(value).__name__}: {value!r}"
-            )
+                    fk = cls(f"{ref}:{pk}")
+            if fk is None:
+                raise TypeError(
+                    f"Cannot validate ForeignKey from {type(value).__name__}: {value!r}"
+                )
+            fk._relational_target = target
+            return fk
 
         def _serialize(value: "ForeignKey") -> str | None:
             if value is None:
                 return None
             return value._target_key
-
-        # TODO: this name-normalization exists only because the metaclass converts a
-        #       ForeignKey's target into a dynamic per-field subclass. Once reference
-        #       targets are kept as static types, this can be removed (or reduced to a thin
-        #       forward-ref-string fallback).
-        #       https://github.com/imaginary-cherry/rapyer/issues/247
-        cls._target_type_hint = target_hint
 
         return core_schema.no_info_plain_validator_function(
             _validate,

--- a/rapyer/types/generic.py
+++ b/rapyer/types/generic.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from abc import ABC
-from typing import Any, Generic, TypeVar, get_args, get_origin
+from typing import Any, Generic, TypeVar, get_origin
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -10,7 +10,7 @@ from pydantic_core.core_schema import CoreSchema, SerializationInfo, ValidationI
 from rapyer.errors import CantSerializeRedisValueError
 from rapyer.types.base import RedisType
 from rapyer.types.special import SpecialFieldType
-from rapyer.utils.pythonic import safe_issubclass
+from rapyer.utils.pythonic import resolve_generic_args, safe_issubclass
 
 logger = logging.getLogger("rapyer")
 
@@ -29,12 +29,12 @@ class GenericRedisType(RedisType, Generic[T], ABC):
 
     @classmethod
     def find_inner_type(cls, type_):
-        args = get_args(type_)
+        args = resolve_generic_args(type_)
         return args[0] if args else Any
 
     @classmethod
     def contains_sf_field(cls) -> bool:
-        inner = cls.find_inner_type(cls.original_type)
+        inner = cls.find_inner_type(cls)
         if inner is Any:
             return False
         if safe_issubclass(inner, SpecialFieldType):
@@ -46,7 +46,7 @@ class GenericRedisType(RedisType, Generic[T], ABC):
 
     @classmethod
     def contains_fk_field(cls) -> bool:
-        inner = cls.find_inner_type(cls.original_type)
+        inner = cls.find_inner_type(cls)
         if inner is Any:
             return False
 
@@ -126,7 +126,7 @@ class GenericRedisType(RedisType, Generic[T], ABC):
             )
         else:
             # Normal serialization for concrete types — preserve inner type args
-            args = get_args(source_type)
+            args = resolve_generic_args(source_type)
             inner_type = cls.build_typed_original(args)
             return core_schema.no_info_after_validator_function(
                 cls, handler(inner_type)

--- a/rapyer/types/generic.py
+++ b/rapyer/types/generic.py
@@ -112,7 +112,7 @@ class GenericRedisType(RedisType, Generic[T], ABC):
         if should_pickle:
             # Build schema with both validator and serializer
             python_schema = core_schema.with_info_before_validator_function(
-                cls.full_deserializer, handler(cls.wrapped_python_type())
+                cls.full_deserializer, handler(cls.wrapped_python_type)
             )
 
             return core_schema.with_info_after_validator_function(

--- a/rapyer/types/generic.py
+++ b/rapyer/types/generic.py
@@ -112,7 +112,7 @@ class GenericRedisType(RedisType, Generic[T], ABC):
         if should_pickle:
             # Build schema with both validator and serializer
             python_schema = core_schema.with_info_before_validator_function(
-                cls.full_deserializer, handler(cls.original_type)
+                cls.full_deserializer, handler(cls.wrapped_python_type())
             )
 
             return core_schema.with_info_after_validator_function(

--- a/rapyer/types/integer.py
+++ b/rapyer/types/integer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from redis.commands.search.field import NumericField
 
@@ -14,6 +14,8 @@ from rapyer.types.base import RedisType
 
 
 class RedisInt(int, RedisType):
+    wrapped_python_type: ClassVar[type] = int
+
     @classmethod
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)

--- a/rapyer/types/integer.py
+++ b/rapyer/types/integer.py
@@ -14,8 +14,6 @@ from rapyer.types.base import RedisType
 
 
 class RedisInt(int, RedisType):
-    original_type = int
-
     @classmethod
     def redis_schema(cls, field_name: str):
         return NumericField(f"$.{field_name}", as_name=field_name)

--- a/rapyer/types/lst.py
+++ b/rapyer/types/lst.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import TYPE_CHECKING, TypeVar, get_origin
+from typing import TYPE_CHECKING, TypeVar
 
 from pydantic_core import core_schema
 from pydantic_core.core_schema import SerializationInfo, ValidationInfo
@@ -17,8 +17,6 @@ T = TypeVar("T")
 
 
 class RedisList(list, GenericRedisType[T]):
-    original_type = list
-
     def __init__(self, *args, **kwargs):
         list.__init__(self, *args, **kwargs)
         GenericRedisType.__init__(self, *args, **kwargs)
@@ -35,10 +33,8 @@ class RedisList(list, GenericRedisType[T]):
 
     @classmethod
     def build_typed_original(cls, source_args):
-        base_type = get_origin(cls.original_type) or cls.original_type
-        # When reconstructing a parameterized type, avoid wrapping the type
-        # arguments in a new tuple; `source_args` already has the correct shape.
-        return base_type[source_args[0]]
+        # ``source_args`` already has the correct shape.
+        return list[source_args[0]]
 
     def sub_field_path(self, key: str):
         return f"{self.field_path}[{key}]"

--- a/rapyer/types/lst.py
+++ b/rapyer/types/lst.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 from pydantic_core import core_schema
 from pydantic_core.core_schema import SerializationInfo, ValidationInfo
@@ -17,6 +17,8 @@ T = TypeVar("T")
 
 
 class RedisList(list, GenericRedisType[T]):
+    wrapped_python_type: ClassVar[type] = list
+
     def __init__(self, *args, **kwargs):
         list.__init__(self, *args, **kwargs)
         GenericRedisType.__init__(self, *args, **kwargs)

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, Generic, Optional, TypeVar, get_args
+from typing import Any, Generic, Optional, TypeVar
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -9,6 +9,7 @@ from rapyer.actions import ActionGroup, mark_actions
 from rapyer.errors.base import RapyerSerializationError
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME
 from rapyer.types.special import SpecialFieldType
+from rapyer.utils.pythonic import resolve_generic_args
 
 T = TypeVar("T")
 
@@ -126,7 +127,7 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        args = get_args(source_type)
+        args = resolve_generic_args(source_type)
         inner = args[0] if args else Any
 
         def _validate_wrap(v, handler_call, info):

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -25,7 +25,6 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
     Priority queue backed by a Redis Sorted Set. Pure Redis proxy — no local state.
     """
 
-    original_type: type = type(None)
     LUA_SNIPPET_DIR = "redis_priority_queue"
 
     # --- Serialization helpers ---

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -151,8 +151,6 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
         def _serialize(v, serializer):
             if isinstance(v, list):
                 return serializer(v)  # ← let pydantic serialize as list[T]
-            if isinstance(v, RedisPriorityQueue):
-                return RedisPriorityQueue()
             return v
 
         schema = handler(list[inner])

--- a/rapyer/types/redis_set.py
+++ b/rapyer/types/redis_set.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Any, Generic, Iterable, Optional, TypeVar, get_args
+from typing import Any, Generic, Iterable, Optional, TypeVar
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -8,6 +8,7 @@ from pydantic_core import core_schema
 from rapyer.actions import ActionGroup, mark_actions
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME
 from rapyer.types.special import SpecialFieldType
+from rapyer.utils.pythonic import resolve_generic_args
 
 T = TypeVar("T")
 
@@ -260,7 +261,7 @@ class RedisSet(set, SpecialFieldType, Generic[T]):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        args = get_args(source_type)
+        args = resolve_generic_args(source_type)
         inner = args[0] if args else Any
 
         def _validate_wrap(v, handler_call, info):

--- a/rapyer/types/redis_set.py
+++ b/rapyer/types/redis_set.py
@@ -243,11 +243,11 @@ class RedisSet(set, SpecialFieldType, Generic[T]):
 
     @classmethod
     def queue_special_loads_in_pipeline(
-        cls, pipe, key: str, plan: list, parent_path: str = ""
+        cls, pipe, key: str, plan: list, parent_path: str = "", field_name: str = ""
     ):
-        field_path = f"{parent_path}{cls.field_name}"
+        field_path = f"{parent_path}{field_name}"
         pipe.smembers(cls.special_field_key(key, field_path))
-        plan.append([cls.field_name.lstrip(".")])
+        plan.append([field_name.lstrip(".")])
 
     def clone(self):
         new = self.__class__()

--- a/rapyer/types/redis_set.py
+++ b/rapyer/types/redis_set.py
@@ -19,7 +19,6 @@ class RedisSet(set, SpecialFieldType, Generic[T]):
     no local state.
     """
 
-    original_type: type = set
     LUA_SNIPPET_DIR = "redis_set"
 
     def __init__(self, *args, **kwargs):

--- a/rapyer/types/relational.py
+++ b/rapyer/types/relational.py
@@ -1,8 +1,7 @@
 import abc
-from typing import TYPE_CHECKING, Any, get_args, get_origin
+from typing import TYPE_CHECKING, Any
 
 from rapyer.types.base import BaseRedisType
-from rapyer.utils.pythonic import safe_issubclass
 
 if TYPE_CHECKING:
     from rapyer.base import AtomicRedisModel
@@ -17,12 +16,7 @@ class RelationalFieldType(BaseRedisType, abc.ABC):
     separate key but is fetched on demand rather than stored separately.
     """
 
-    # The generic argument as captured at class-build time: a model class, a
-    # forward-ref string, or a metaclass-converted per-field subclass.
-    _target_type_hint: Any = None
-    # The canonical, registered target model. Populated once at init by
-    # ``resolve_relational_targets`` and read by ``afetch`` — never resolved
-    # per fetch.
+    # This tells us what is the type we refer to
     _relational_target: "type[AtomicRedisModel] | None" = None
 
     @property
@@ -48,62 +42,15 @@ class RelationalFieldType(BaseRedisType, abc.ABC):
         """Resolve the target from Redis and cache it in-place."""
 
 
-def _resolve_target_model(target_hint: Any) -> "type[AtomicRedisModel] | None":
-    """
-    Map a generic argument to the canonical, registered top-level model.
-
-    Resolves by ``__name__`` against ``REDIS_MODELS`` so a forward-ref string or
-    the metaclass-converted per-field subclass both collapse to the registered,
-    detached model. Returns ``None`` for an unbound ``TypeVar``.
-    """
-    # TODO: this name-normalization exists only because the metaclass converts a
-    #       ForeignKey's target into a dynamic per-field subclass. Once reference
-    #       targets are kept as static types, this can be removed (or reduced to a thin
-    #       forward-ref-string fallback).
-    #       https://github.com/imaginary-cherry/rapyer/issues/247
-    from rapyer.base import REDIS_MODELS
-
-    name = (
-        target_hint
-        if isinstance(target_hint, str)
-        else getattr(target_hint, "__name__", None)
-    )
-    if name is None:
-        return None
-    for model in REDIS_MODELS:
-        if model.__name__ == name:
-            return model
-    if isinstance(target_hint, str):
-        raise NameError(
-            f"ForeignKey target {target_hint!r} is not a registered rapyer model"
-        )
-    return None
-
-
-def _iter_relational_types(annotation: Any):
-    """Yield every ``RelationalFieldType`` subclass reachable in an annotation."""
-    origin = get_origin(annotation) or annotation
-    if safe_issubclass(origin, RelationalFieldType):
-        yield origin
-        return
-    for arg in get_args(annotation):
-        yield from _iter_relational_types(arg)
-
-
 def resolve_relational_targets(models) -> None:
     """
-    Resolve and cache every relational field's target model, once.
+    Rebuild every model that holds a reference so pydantic resolves forward-ref
+    targets to real classes.
 
-    Called at the init stage (``init_rapyer``) after all models are registered,
-    so forward references and self-references all resolve. Only the fields the
-    metaclass already flagged (``_relational_field_names`` + ``_contain_fk``) are
-    visited — no recursive scan of every field — and each target is cached on its
-    field type, so ``afetch`` never hits the registry.
+    A forward reference to a model defined later stays unresolved in the field
+    annotation otherwise. Each ``ForeignKey`` stamps its resolved target onto the
+    instance at validation time, so this only needs to force that rebuild.
     """
     for model in models:
-        for fname in model._relational_field_names | model._contain_fk:
-            annotation = model.model_fields[fname].annotation
-            for rel_type in _iter_relational_types(annotation):
-                rel_type._relational_target = _resolve_target_model(
-                    rel_type._target_type_hint
-                )
+        if model.contains_fk_field():
+            model.model_rebuild(force=True)

--- a/rapyer/types/relational.py
+++ b/rapyer/types/relational.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args
 
 from rapyer.types.base import BaseRedisType
 
@@ -16,8 +16,12 @@ class RelationalFieldType(BaseRedisType, abc.ABC):
     separate key but is fetched on demand rather than stored separately.
     """
 
-    # This tells us what is the type we refer to
-    _relational_target: "type[AtomicRedisModel] | None" = None
+    @property
+    def _relational_target(self) -> "type[AtomicRedisModel] | None":
+        """Find the refernced class"""
+        orig = getattr(self, "__orig_class__", None)
+        args = get_args(orig) if orig is not None else ()
+        return args[0] if args else None
 
     @property
     @abc.abstractmethod

--- a/rapyer/types/string.py
+++ b/rapyer/types/string.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from rapyer.actions import ActionGroup, mark_actions, marks_redis_updated
 from rapyer.scripts import STR_APPEND_SCRIPT_NAME, STR_MUL_SCRIPT_NAME, run_sha
@@ -6,6 +6,8 @@ from rapyer.types.base import RedisType
 
 
 class RedisStr(str, RedisType):
+    wrapped_python_type: ClassVar[type] = str
+
     def clone(self):
         return str(self)
 

--- a/rapyer/types/string.py
+++ b/rapyer/types/string.py
@@ -6,8 +6,6 @@ from rapyer.types.base import RedisType
 
 
 class RedisStr(str, RedisType):
-    original_type = str
-
     def clone(self):
         return str(self)
 

--- a/rapyer/utils/annotation.py
+++ b/rapyer/utils/annotation.py
@@ -3,6 +3,9 @@ from abc import ABC
 from types import UnionType
 from typing import Annotated, Any, Union, get_args, get_origin
 
+from rapyer.types.relational import RelationalFieldType
+from rapyer.utils.pythonic import safe_issubclass
+
 DYNAMIC_CLASS_DOC = "___dynamic_class___"
 
 
@@ -29,6 +32,10 @@ def replace_to_redis_types_in_annotation(
     Recursively traverse a type annotation and replace types according to the mapping.
     Handles Union, Optional, Annotated, and other generic types.
     """
+    # Relational field is not dynamically created, it stays simple field
+    if safe_issubclass(get_origin(annotation) or annotation, RelationalFieldType):
+        return annotation
+
     # Direct type replacement
     if type_converter.is_type_support(annotation):
         new_type = type_converter.convert_flat_type(annotation)

--- a/rapyer/utils/annotation.py
+++ b/rapyer/utils/annotation.py
@@ -92,6 +92,15 @@ def strip_optional(annotation: Any) -> Any:
     return annotation
 
 
+def annotation_origin(annotation: Any) -> Any:
+    """Peel ``Annotated`` and ``Optional`` wrappers and return the underlying origin type."""
+    unwrapped = annotation
+    while get_origin(unwrapped) is Annotated:
+        unwrapped = get_args(unwrapped)[0]
+    unwrapped = strip_optional(unwrapped)
+    return get_origin(unwrapped) or unwrapped
+
+
 def has_annotation(field: Any, annotation_type: Any) -> bool:
     origin = get_origin(field)
     if origin is Annotated:

--- a/rapyer/utils/pythonic.py
+++ b/rapyer/utils/pythonic.py
@@ -1,8 +1,26 @@
+from typing import TypeVar, get_args
+
+
 def safe_issubclass(cls, class_or_tuple):
     try:
         return issubclass(cls, class_or_tuple)
     except TypeError:
         return False
+
+
+def resolve_generic_args(type_) -> tuple:
+    """
+    Type args of a parameterized alias (``RedisList[str]``) or of a class that
+    subclasses one, recovered from ``__orig_bases__`` (``class C(RedisList[str])``).
+    """
+    args = get_args(type_)
+    if args:
+        return args
+    for base in getattr(type_, "__orig_bases__", ()):
+        base_args = get_args(base)
+        if base_args and not all(isinstance(a, TypeVar) for a in base_args):
+            return base_args
+    return ()
 
 
 def inject_at_paths(model_dump: dict, plan: list[list[str]], raw_results: list):

--- a/tests/action_groups.py
+++ b/tests/action_groups.py
@@ -208,3 +208,11 @@ SYNC_NATIVE_RAISES_GROUP = SYNC_NATIVE_EFFECT_GROUP | _group(
     RedisList.clear,
     RedisDict.clear,
 )
+
+
+# ADDITIONAL_READ_ACTIONS — read/fetch actions that are not marked with the
+# READ action group, so the group-based ``ignore_groups=READ`` exclusion misses
+# them. They resolve and return a value and cannot be deferred inside a pipeline,
+# so pipeline-atomicity does not apply. Excluded from COVER_PIPELINE_ATOM
+# alongside the marked READ actions.
+ADDITIONAL_READ_ACTIONS = _group(ForeignKey.afetch)

--- a/tests/action_groups.py
+++ b/tests/action_groups.py
@@ -54,7 +54,7 @@ PRIVATE_METHODS = _group(
     AtomicRedisModel.redis_dump_json,
     AtomicRedisModel.redis_dump,
     AtomicRedisModel.is_inner_model,
-    AtomicRedisModel.assign_fields_links,
+    AtomicRedisModel.model_post_init,
     AtomicRedisModel.validate_sub_model,
     AtomicRedisModel._all_keys_for_key,
     AtomicRedisModel._iter_expanded_filter_batches,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,8 @@ COVERAGE_CHECKS: list[CoverageCheck] = [
     CoverageCheck(
         name=COVER_PIPELINE_ATOM,
         help_text="pipeline atomicity",
-        expected=lambda: _collect_methods(ignore_groups=ActionGroup.READ),
+        expected=lambda: _collect_methods(ignore_groups=ActionGroup.READ)
+        - ADDITIONAL_READ_ACTIONS,
     ),
     CoverageCheck(
         name=COVER_READ_IN_PIPELINE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from rapyer.base import AtomicRedisModel
 from rapyer.types.base import BaseRedisType
 from rapyer.types.special import SpecialFieldType
 from tests.action_groups import (
+    ADDITIONAL_READ_ACTIONS,
     NON_ACTION_METHODS,
     PRIVATE_INHERITED_METHODS,
     PRIVATE_METHODS,

--- a/tests/integration/actions/redis_types/test_foreign_key.py
+++ b/tests/integration/actions/redis_types/test_foreign_key.py
@@ -16,7 +16,9 @@ class TestForeignKeyAfetch(ReadActionTestBase, TTLActionTestBase):
 
     def create_models(self):
         target = ComprehensiveTestModel(name="resolved", counter=7)
-        return [ComprehensiveRefOwner(ref=target), target]
+        # Reference by key (unresolved) so afetch actually fetches via the
+        # target's aget — that read/fetch is what refreshes the target's TTL.
+        return [ComprehensiveRefOwner(ref=target.key), target]
 
     def ttl_keys(self, model):
         return list(model.all_keys)
@@ -32,6 +34,12 @@ class TestForeignKeyAfetch(ReadActionTestBase, TTLActionTestBase):
     def models_to_check_ttl(self):
         # afetch refreshes the fetched target, so its TTL is what we assert.
         return [self.created_models[1]]
+
+    def model_to_refresh(self):
+        # afetch resolves the target via ``target_cls.aget``; the refresh is
+        # governed by the target's settings, so install the wrapper on (and
+        # take the reference TTL from) the resolved target, not the owner.
+        return self.created_models[1]
 
     def expected_before(self):
         # afetch returns the hydrated target (the same cached instance).

--- a/tests/integration/actions/ttl.py
+++ b/tests/integration/actions/ttl.py
@@ -47,6 +47,13 @@ class TTLActionTestBase(AsyncActionTestBase, ABC):
     def models_to_check_ttl(self):
         return self.created_models
 
+    def model_to_refresh(self):
+        """Model whose class receives the refresh-ttl wrapper and whose
+        configured TTL is the reference for the assertion. Defaults to the
+        acted-on model; override when the action refreshes a different model
+        (e.g. afetch refreshes the resolved target, not the owner)."""
+        return self.created_models[0]
+
     def all_keys_to_check(self):
         keys = []
         for model in self.models_to_check_ttl():
@@ -145,6 +152,7 @@ class TTLActionTestBase(AsyncActionTestBase, ABC):
         # Arrange
         self.created_models = await self._setup_ttl_data()
         model_for_keys = self.created_models[0]
+        model_to_refresh = self.model_to_refresh()
         ttls_before = None
         if self.model_exists_before_action:
             keys = self.all_keys_to_check()
@@ -154,14 +162,14 @@ class TTLActionTestBase(AsyncActionTestBase, ABC):
 
         # Act
         with self.installed_refresh_ttl(
-            type(model_for_keys),
+            type(model_to_refresh),
             ActionGroup.all(for_ttl=True),
         ):
             await self.perform_action(model_for_keys)
 
         # Assert
         keys = self.all_keys_to_check()
-        ttl_configured = model_for_keys.Meta.ttl
+        ttl_configured = model_to_refresh.Meta.ttl
         afters = await asyncio.gather(
             *[self.real_redis_client.ttl(key) for key in keys]
         )
@@ -183,7 +191,7 @@ class TTLActionTestBase(AsyncActionTestBase, ABC):
 
         # Act
         with self.installed_refresh_ttl(
-            type(model_for_keys),
+            type(self.model_to_refresh()),
             ActionGroup(0),
         ):
             await self.perform_action(model_for_keys)
@@ -207,7 +215,7 @@ class TTLActionTestBase(AsyncActionTestBase, ABC):
         # Act
         with (
             self.installed_refresh_ttl(
-                type(model_for_keys), ActionGroup.all(for_ttl=True)
+                type(self.model_to_refresh()), ActionGroup.all(for_ttl=True)
             ),
             patch.object(actions_module, "flush_action_targets", flush_spy),
             patch.object(Redis, "expire", redis_expire_spy),

--- a/tests/integration/foreign_keys/test_foreign_key.py
+++ b/tests/integration/foreign_keys/test_foreign_key.py
@@ -296,5 +296,3 @@ async def test_afetch_does_not_refresh_referenced_model_ttl(
     # The owner does refresh on read/fetch, proving the fetch path actually ran.
     owner_ttl = await real_redis_client.ttl(owner.key)
     assert FK_TTL_SECONDS - 2 < owner_ttl <= FK_TTL_SECONDS
-
-

--- a/tests/integration/foreign_keys/test_foreign_key.py
+++ b/tests/integration/foreign_keys/test_foreign_key.py
@@ -1,13 +1,18 @@
 import pytest
+import pytest_asyncio
 
 from rapyer.errors import KeyNotFound
+from tests.integration.conftest import REDUCED_TTL_SECONDS
 from tests.integration.foreign_keys.conftest import MISSING_AUTHOR_KEY
 from tests.models.foreign_key_types import (
+    FK_TTL_SECONDS,
     FkAuthor,
     FkBook,
     FkLibrary,
     FkRichAuthor,
     FkTree,
+    FkTTLOwner,
+    FkTTLReferee,
 )
 
 # --- Required FK (FkBook.author) ---
@@ -247,3 +252,49 @@ async def test_forward_ref_self_link():
 
     # Assert
     assert loaded.parent.value.name == "root"
+
+
+# --- TTL refresh across a reference ---
+
+
+@pytest_asyncio.fixture
+async def owner_with_referee(real_redis_client):
+    """Saved owner -> referee pair, with the referee's TTL manually reduced so a
+    refresh would be observable as a jump back toward FK_TTL_SECONDS."""
+    referee = FkTTLReferee(name="referee")
+    await referee.asave()
+    owner = FkTTLOwner(title="owner", referee=referee.key)
+    await owner.asave()
+
+    await real_redis_client.expire(referee.key, REDUCED_TTL_SECONDS)
+    await real_redis_client.expire(owner.key, REDUCED_TTL_SECONDS)
+    initial_referee_ttl = await real_redis_client.ttl(referee.key)
+
+    yield owner, referee, initial_referee_ttl
+
+    await owner.adelete()
+    await referee.adelete()
+
+
+@pytest.mark.asyncio
+async def test_afetch_does_not_refresh_referenced_model_ttl(
+    real_redis_client, owner_with_referee
+):
+    # Arrange
+    owner, referee, initial_referee_ttl = owner_with_referee
+    assert initial_referee_ttl <= REDUCED_TTL_SECONDS
+
+    # Act - load the owner and resolve the reference (both are read/fetch ops).
+    loaded = await FkTTLOwner.aget(owner.key)
+    await loaded.referee.afetch()
+
+    # Assert - the referee does not refresh on read/fetch, so its TTL stays in
+    # the reduced window instead of jumping back up to FK_TTL_SECONDS.
+    referee_ttl = await real_redis_client.ttl(referee.key)
+    assert 0 < referee_ttl <= REDUCED_TTL_SECONDS
+
+    # The owner does refresh on read/fetch, proving the fetch path actually ran.
+    owner_ttl = await real_redis_client.ttl(owner.key)
+    assert FK_TTL_SECONDS - 2 < owner_ttl <= FK_TTL_SECONDS
+
+

--- a/tests/models/collection_types.py
+++ b/tests/models/collection_types.py
@@ -131,7 +131,9 @@ class ProductListModel(AtomicRedisModel):
 
 class SpecialFieldsContainer(AtomicRedisModel):
     labels: RedisSet[str] = Field(default_factory=RedisSet[str])
-    tasks: RedisPriorityQueue[float] = Field(default_factory=RedisPriorityQueue[float])
+    tasks: RedisPriorityQueue[float] = Field(
+        default_factory=RedisPriorityQueue[float], exclude=True
+    )
 
 
 class ComprehensiveTestModel(PipelineActionModel):
@@ -143,7 +145,9 @@ class ComprehensiveTestModel(PipelineActionModel):
     data: bytes = b""
     event_time: datetime = Field(default_factory=datetime.now)
     event_timestamp: RedisDatetimeTimestamp = Field(default_factory=datetime.now)
-    tasks: RedisPriorityQueue[int] = Field(default_factory=RedisPriorityQueue[int])
+    tasks: RedisPriorityQueue[int] = Field(
+        default_factory=RedisPriorityQueue[int], exclude=True
+    )
     container: SpecialFieldsContainer = Field(default_factory=SpecialFieldsContainer)
     author: Optional[Reference[FkAuthor]] = None
 

--- a/tests/models/foreign_key_types.py
+++ b/tests/models/foreign_key_types.py
@@ -1,10 +1,14 @@
-from typing import Optional
+from typing import ClassVar, Optional
 
 from pydantic import Field
 
+from rapyer.actions import ActionGroup
 from rapyer.base import AtomicRedisModel
+from rapyer.config import RedisConfig
 from rapyer.types.foreign_key import Reference
 from rapyer.types.redis_set import RedisSet
+
+FK_TTL_SECONDS = 24
 
 
 class FkProfile(AtomicRedisModel):
@@ -42,3 +46,26 @@ class FkBook(AtomicRedisModel):
 class FkTree(AtomicRedisModel):
     name: str = "root"
     parent: Optional[Reference["FkTree"]] = None
+
+
+class FkTTLReferee(AtomicRedisModel):
+    """Referenced model that refreshes TTL on writes only, never on reads/fetches."""
+
+    name: str = "referee"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=FK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.CREATE | ActionGroup.UPDATE | ActionGroup.APPEND,
+    )
+
+
+class FkTTLOwner(AtomicRedisModel):
+    """Main model that refreshes TTL on read, fetch and update."""
+
+    title: str = "owner"
+    referee: Reference[FkTTLReferee]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=FK_TTL_SECONDS,
+        refresh_ttl=ActionGroup.READ | ActionGroup.FETCH | ActionGroup.UPDATE,
+    )

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -41,6 +41,8 @@ from tests.models.foreign_key_types import (
     FkPublisher,
     FkRichAuthor,
     FkTree,
+    FkTTLOwner,
+    FkTTLReferee,
 )
 from tests.models.functionality_types import (
     AllTypesModel,
@@ -228,4 +230,6 @@ TESTED_REDIS_MODELS = [
     FkProfile,
     FkRichAuthor,
     FkLibrary,
+    FkTTLReferee,
+    FkTTLOwner,
 ]

--- a/tests/models/special_types.py
+++ b/tests/models/special_types.py
@@ -11,7 +11,9 @@ T = TypeVar("T")
 
 
 class PriorityQueueModelBase(AtomicRedisModel, Generic[T]):
-    tasks: RedisPriorityQueue[T] = Field(default_factory=RedisPriorityQueue)
+    tasks: RedisPriorityQueue[T] = Field(
+        default_factory=RedisPriorityQueue, exclude=True
+    )
 
 
 class PriorityQueueModel(PriorityQueueModelBase[str]):
@@ -31,12 +33,14 @@ class MixedSpecialModel(PriorityQueueModelBase[str]):
 
 class OptionalPriorityQueueModel(AtomicRedisModel):
     name: str = "default"
-    tasks: Optional[RedisPriorityQueue[str]] = None
+    tasks: Optional[RedisPriorityQueue[str]] = Field(default=None, exclude=True)
 
 
 class GenericPriorityQueueModel(AtomicRedisModel, Generic[T]):
     name: str = "default"
-    tasks: RedisPriorityQueue[T] = Field(default_factory=RedisPriorityQueue)
+    tasks: RedisPriorityQueue[T] = Field(
+        default_factory=RedisPriorityQueue, exclude=True
+    )
 
 
 class SubSubPriorityQueueModel(PriorityQueueModel):
@@ -54,12 +58,16 @@ class PQContainerModel(AtomicRedisModel):
 
 class InnerSameNamePQModel(AtomicRedisModel):
     label: str = "inner"
-    tasks: RedisPriorityQueue[str] = Field(default_factory=RedisPriorityQueue)
+    tasks: RedisPriorityQueue[str] = Field(
+        default_factory=RedisPriorityQueue, exclude=True
+    )
 
 
 class NestedSameNamePQModel(AtomicRedisModel):
     name: str = "outer"
-    tasks: RedisPriorityQueue[str] = Field(default_factory=RedisPriorityQueue)
+    tasks: RedisPriorityQueue[str] = Field(
+        default_factory=RedisPriorityQueue, exclude=True
+    )
     inner: InnerSameNamePQModel = Field(default_factory=InnerSameNamePQModel)
 
 

--- a/tests/unit/models/test_model_dump.py
+++ b/tests/unit/models/test_model_dump.py
@@ -2,11 +2,12 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from rapyer.base import AtomicRedisModel
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME
 from tests.models.collection_types import (
+    ComprehensiveTestModel,
     MixedTypesModel,
     SimpleDictModel,
     SimpleListModel,
@@ -512,3 +513,40 @@ def test_redis_dump_skips_field_marked_exclude_true_sanity():
     # Assert
     assert "secret" not in redis_data
     assert redis_data["name"] == "my_model"
+
+
+def test_atomic_and_plain_models_dump_identically_for_native_fields_sanity():
+    # Arrange
+    shared_values = dict(
+        tags=["alpha", "beta"],
+        metadata={"key": "value", "env": "prod"},
+        name="comprehensive",
+        counter=42,
+        amount=3.14,
+        data=b"raw-bytes",
+        event_time=datetime(2023, 6, 15, 10, 30, 45),
+    )
+
+    class PlainComprehensiveModel(BaseModel):
+        tags: list[str] = Field(default_factory=list)
+        metadata: dict[str, str] = Field(default_factory=dict)
+        name: str = ""
+        counter: int = 0
+        amount: float = 0.0
+        data: bytes = b""
+        event_time: datetime = Field(default_factory=datetime.now)
+
+    # Arrange — same values fed to the atomic model and its plain twin
+    atomic = ComprehensiveTestModel(**shared_values)
+    plain = PlainComprehensiveModel(**shared_values)
+
+    # Act & Assert — python mode
+    atomic_dump_json = atomic.model_dump(mode="json")
+    plain_dump_json = plain.model_dump(mode="json")
+
+    atomic_dump = atomic.model_dump()
+    plain_dump = plain.model_dump()
+
+    # Assert
+    assert atomic_dump == plain_dump
+    assert atomic_dump_json == plain_dump_json

--- a/tests/unit/models/test_model_dump.py
+++ b/tests/unit/models/test_model_dump.py
@@ -11,6 +11,7 @@ from tests.models.collection_types import (
     MixedTypesModel,
     SimpleDictModel,
     SimpleListModel,
+    SpecialFieldsContainer,
 )
 from tests.models.common import Priority, TaskStatus
 from tests.models.complex_types import (
@@ -519,9 +520,6 @@ def test_atomic_and_plain_models_dump_identically_for_native_fields_sanity():
     # Arrange
     excluded = {"event_timestamp", "author"}
 
-    class PlainContainer(BaseModel):
-        labels: set[str] = Field(default_factory=set)
-
     class PlainComprehensiveModel(BaseModel):
         tags: list[str] = Field(default_factory=list)
         metadata: dict[str, str] = Field(default_factory=dict)
@@ -530,7 +528,9 @@ def test_atomic_and_plain_models_dump_identically_for_native_fields_sanity():
         amount: float = 0.0
         data: bytes = b""
         event_time: datetime = Field(default_factory=datetime.now)
-        container: PlainContainer = Field(default_factory=PlainContainer)
+        container: SpecialFieldsContainer = Field(
+            default_factory=SpecialFieldsContainer
+        )
         pipeline_no_clobber_sentinel: str = "INIT_CLOBBER_SENTINEL"
 
     shared_values = dict(

--- a/tests/unit/models/test_model_dump.py
+++ b/tests/unit/models/test_model_dump.py
@@ -517,6 +517,22 @@ def test_redis_dump_skips_field_marked_exclude_true_sanity():
 
 def test_atomic_and_plain_models_dump_identically_for_native_fields_sanity():
     # Arrange
+    excluded = {"event_timestamp", "author"}
+
+    class PlainContainer(BaseModel):
+        labels: set[str] = Field(default_factory=set)
+
+    class PlainComprehensiveModel(BaseModel):
+        tags: list[str] = Field(default_factory=list)
+        metadata: dict[str, str] = Field(default_factory=dict)
+        name: str = ""
+        counter: int = 0
+        amount: float = 0.0
+        data: bytes = b""
+        event_time: datetime = Field(default_factory=datetime.now)
+        container: PlainContainer = Field(default_factory=PlainContainer)
+        pipeline_no_clobber_sentinel: str = "INIT_CLOBBER_SENTINEL"
+
     shared_values = dict(
         tags=["alpha", "beta"],
         metadata={"key": "value", "env": "prod"},
@@ -527,25 +543,16 @@ def test_atomic_and_plain_models_dump_identically_for_native_fields_sanity():
         event_time=datetime(2023, 6, 15, 10, 30, 45),
     )
 
-    class PlainComprehensiveModel(BaseModel):
-        tags: list[str] = Field(default_factory=list)
-        metadata: dict[str, str] = Field(default_factory=dict)
-        name: str = ""
-        counter: int = 0
-        amount: float = 0.0
-        data: bytes = b""
-        event_time: datetime = Field(default_factory=datetime.now)
-
     # Arrange — same values fed to the atomic model and its plain twin
     atomic = ComprehensiveTestModel(**shared_values)
     plain = PlainComprehensiveModel(**shared_values)
 
     # Act & Assert — python mode
-    atomic_dump_json = atomic.model_dump(mode="json")
-    plain_dump_json = plain.model_dump(mode="json")
+    atomic_dump_json = atomic.model_dump(mode="json", exclude=excluded)
+    plain_dump_json = plain.model_dump(mode="json", exclude=excluded)
 
-    atomic_dump = atomic.model_dump()
-    plain_dump = plain.model_dump()
+    atomic_dump = atomic.model_dump(exclude=excluded)
+    plain_dump = plain.model_dump(exclude=excluded)
 
     # Assert
     assert atomic_dump == plain_dump

--- a/tests/unit/test_base_functions.py
+++ b/tests/unit/test_base_functions.py
@@ -5,7 +5,9 @@ import pytest
 
 from rapyer import AtomicRedisModel
 from rapyer.base import find_redis_models
-from rapyer.errors import DuplicateModelNameError
+from rapyer.config import RedisConfig
+from rapyer.errors import DuplicateModelNameError, UnsupportedIndexedFieldError
+from rapyer.fields import Index
 
 T = TypeVar("T")
 
@@ -66,3 +68,21 @@ def test_registering_two_models_with_same_class_name_raises(clean_redis_models):
             field2: int = 0
 
     assert exc_info.value.model_name == "DuplicateNameModel"
+
+
+def test_redis_schema_raises_for_indexed_field_with_unsupported_scalar_type_sanity(
+    clean_redis_models,
+):
+    # ``complex`` is a valid pydantic type but has no RedisType conversion, so its
+    # annotation reaches redis_schema unconverted. With the Index flag set it is not
+    # an AtomicRedisModel nor a RedisType, so it falls through to the final guard that
+    # rejects indexed fields whose type Redis cannot index.
+    class IndexedComplexModel(AtomicRedisModel):
+        name: str
+        value: Index[complex]
+
+        Meta = RedisConfig(init_with_rapyer=False)
+
+    # Act & Assert
+    with pytest.raises(UnsupportedIndexedFieldError):
+        IndexedComplexModel.redis_schema()

--- a/tests/unit/test_base_functions.py
+++ b/tests/unit/test_base_functions.py
@@ -41,7 +41,6 @@ def test_find_redis_models_returns_all_loaded_models_sanity(clean_redis_models):
         Model2,
         Model3,
         Model4,
-        GenericModel,
         GenericModel[type],
         GenericModel[Model],
     }
@@ -51,6 +50,8 @@ def test_find_redis_models_returns_all_loaded_models_sanity(clean_redis_models):
 
     # Assert
     assert set(models) == expected
+    # Generic model is not registered
+    assert GenericModel not in models
 
 
 def test_registering_two_models_with_same_class_name_raises(clean_redis_models):

--- a/tests/unit/types/test_foreign_key.py
+++ b/tests/unit/types/test_foreign_key.py
@@ -1,12 +1,15 @@
 import json
+from typing import Optional, get_origin
 
 import pytest
 from pydantic import TypeAdapter
 
+from rapyer.base import AtomicRedisModel
 from rapyer.errors import NotResolvedError
 from rapyer.types import Reference
 from rapyer.types.foreign_key import ForeignKey
-from rapyer.types.relational import RelationalFieldType, _resolve_target_model
+from rapyer.types.relational import RelationalFieldType, resolve_relational_targets
+from rapyer.utils.pythonic import resolve_generic_args
 from tests.models.foreign_key_types import FkAuthor, FkBook
 
 # --- Class-build introspection ---
@@ -36,6 +39,39 @@ def test_relational_fields_are_also_redis_link_fields():
 def test_reference_is_relational_field_type():
     # Arrange / Act / Assert
     assert issubclass(Reference, RelationalFieldType)
+
+
+def test_foreign_key_fields_are_not_dynamically_subclassed():
+    # The converter leaves relational types untouched, so every FK field uses the
+    # one shared ForeignKey class (parameterized or bare) — never a per-field
+    # dynamic subclass.
+    # Arrange
+    def fk_origin(annotation):
+        annotation_origin = get_origin(annotation) or annotation
+        if isinstance(annotation_origin, type) and issubclass(annotation_origin, ForeignKey):
+            return annotation_origin
+        # Converted containers (e.g. list[ForeignKey[X]]) are concrete subclasses
+        # that carry their args in __orig_bases__, not get_args — descend via the
+        # same helper the runtime uses.
+        for arg in resolve_generic_args(annotation):
+            found = fk_origin(arg)
+            if found is not None:
+                return found
+        return None
+
+    # ACT
+    class BareRefHolder(AtomicRedisModel):
+        ref: Optional[Reference] = None
+
+    # Assert
+    for model, field in [
+        (FkBook, "author"),
+        (FkBook, "publisher"),
+        (FkBook, "co_authors"),
+        (BareRefHolder, "ref"),
+    ]:
+        origin = fk_origin(model.model_fields[field].annotation)
+        assert origin is ForeignKey, f"{model.__name__}.{field} is {origin!r}"
 
 
 # --- Pydantic validator: accepts multiple shapes ---

--- a/tests/unit/types/test_foreign_key.py
+++ b/tests/unit/types/test_foreign_key.py
@@ -8,7 +8,7 @@ from rapyer.base import AtomicRedisModel
 from rapyer.errors import NotResolvedError
 from rapyer.types import Reference
 from rapyer.types.foreign_key import ForeignKey
-from rapyer.types.relational import RelationalFieldType, resolve_relational_targets
+from rapyer.types.relational import RelationalFieldType
 from rapyer.utils.pythonic import resolve_generic_args
 from tests.models.foreign_key_types import FkAuthor, FkBook
 
@@ -48,7 +48,9 @@ def test_foreign_key_fields_are_not_dynamically_subclassed():
     # Arrange
     def fk_origin(annotation):
         annotation_origin = get_origin(annotation) or annotation
-        if isinstance(annotation_origin, type) and issubclass(annotation_origin, ForeignKey):
+        if isinstance(annotation_origin, type) and issubclass(
+            annotation_origin, ForeignKey
+        ):
             return annotation_origin
         # Converted containers (e.g. list[ForeignKey[X]]) are concrete subclasses
         # that carry their args in __orig_bases__, not get_args — descend via the
@@ -287,31 +289,3 @@ def test_serializer_handles_none():
     # serializing None directly through the type adapter, hence a unit test.
     # Act / Assert
     assert TypeAdapter(ForeignKey).dump_python(None) is None
-
-
-def test_resolve_target_model_returns_none_for_unnamed_hint():
-    # Coverage: _resolve_target_model's branch for a hint with no resolvable
-    # name (None) — returns None instead of looking it up.
-    # Act / Assert
-    assert _resolve_target_model(None) is None
-
-
-def test_resolve_target_model_returns_none_for_unregistered_non_string_hint():
-    # Coverage: _resolve_target_model's final `return None` for a non-string
-    # hint whose name matches no registered model.
-    # Arrange
-    class NotAModel:
-        pass
-
-    # Act / Assert
-    # A non-string hint whose name matches no registered model yields None
-    # (only string hints raise — they are explicit forward references).
-    assert _resolve_target_model(NotAModel) is None
-
-
-def test_resolve_target_model_unregistered_string_raises():
-    # Coverage: _resolve_target_model's NameError branch for a string forward
-    # reference that names no registered model.
-    # Act / Assert
-    with pytest.raises(NameError):
-        _resolve_target_model("NotARegisteredRapyerModel")

--- a/tests/unit/types/test_special_types.py
+++ b/tests/unit/types/test_special_types.py
@@ -94,12 +94,16 @@ def test_priority_queue_clone():
     assert isinstance(clone, RedisPriorityQueue)
 
 
-def test_priority_queue_model_dump_serializes_none():
+def test_priority_queue_excluded_from_model_dump():
     model = PriorityQueueModel(name="test")
-    dump = model.model_dump()
 
-    assert isinstance(dump["tasks"], RedisPriorityQueue)
-    assert dump["name"] == "test"
+    python_dump = model.model_dump()
+    json_dump = model.model_dump(mode="json")
+
+    assert "tasks" not in python_dump
+    assert "tasks" not in json_dump
+    assert python_dump["name"] == "test"
+    assert json_dump["name"] == "test"
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py{310,311,312,313}-redis{60,61,62,63,64,70,71,72,73,74}-pydantic{211,212,213}
+    py{310,311,312,313}-redis{60,61,62,63,64,70,71,72,73,74,80}-pydantic{211,212,213}
     lint
     mypy
 skip_missing_interpreters = true
@@ -25,6 +25,7 @@ deps =
     redis72: redis[async]>=7.2.0,<7.3.0
     redis73: redis[async]>=7.3.0,<7.4.0
     redis74: redis[async]>=7.4.0,<7.5.0
+    redis80: redis[async]>=8.0.0,<8.1.0
     pydantic211: pydantic>=2.11.0,<2.12.0
     pydantic212: pydantic>=2.12.0,<2.13.0
     pydantic213: pydantic>=2.13.0,<2.14.0
@@ -42,8 +43,8 @@ commands =
 deps = 
     mypy>=1.0.0
     pydantic>=2.11.0,<2.14.0
-    redis[async]>=6.0.0,<7.5.0
-commands = 
+    redis[async]>=6.0.0,<8.1.0
+commands =
     pip install -e . --no-deps
     mypy --follow-imports=skip --no-error-summary --disable-error-code=valid-type tests/models
 

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -238,6 +247,15 @@ toml = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -269,6 +287,15 @@ json = [
 ]
 lua = [
     { name = "lupa" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -490,11 +517,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.2"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -639,6 +666,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d7/29e1e5e882f79133631f7bcace42d23db493f616463c157a1ab614bf69dd/pyproject_api-1.10.1-py3-none-any.whl", hash = "sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a", size = 12992, upload-time = "2026-05-28T14:22:12.711Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -720,6 +760,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -750,7 +803,7 @@ wheels = [
 
 [[package]]
 name = "rapyer"
-version = "1.3.3"
+version = "1.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -763,6 +816,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "tox" },
 ]
 
 [package.dev-dependencies]
@@ -785,6 +839,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
     { name = "redis", specifier = ">=6.0.0,<8.1.0" },
+    { name = "tox", marker = "extra == 'test'", specifier = ">=4.55.1" },
 ]
 provides-extras = ["test"]
 
@@ -896,6 +951,38 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tox"
+version = "4.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyproject-api" },
+    { name = "python-discovery" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/5b/4f09156a3f7bf3c4fa23212717f097c59126d81e2c557e6fd872a62db38a/tox-4.55.1.tar.gz", hash = "sha256:0678fbf26dd5b559b1ef128fa4388325920219322ebc8cc5f3497627c00f4472", size = 280676, upload-time = "2026-06-03T20:01:03.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fd/394f00f3d3e23d87eb7b20276d88fe835e48780d3eb30e6f362428bb80c8/tox-4.55.1-py3-none-any.whl", hash = "sha256:e2084be6dfdef96ba1bed4948e6a1f73613d6952e1477be5dca45653d4c053c8", size = 215360, upload-time = "2026-06-03T20:01:01.967Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -914,4 +1001,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
-    { name = "redis", specifier = ">=6.0.0,<7.5.0" },
+    { name = "redis", specifier = ">=6.0.0,<8.1.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

Removes rapyer's runtime creation of dynamic classes. Previously, defining a model generated a per-field dynamic subclass of each redis type (and references) so it could bake in per-field state (`field_name`, `original_type`, the type adapter). This branch reuses the static generic classes instead and recovers what it needs from the generic parameterization, so no new classes are minted at model-definition time.

Closes #247

## Changes

- **No runtime dynamic classes for typed fields**: the converter now reuses the static generic classes (`RedisList[str]`, `RedisDict`, `Reference[T]`, …) and reads the inner element type from the concrete parameterization (`get_args` / `__orig_bases__`) instead of generating a subclass per field.
  - `field_name` moved from a baked class attribute to per-instance state.
  - The `original_type` class variable was removed; the wrapped builtin is derived (or passed as a literal) where needed.
  - Foreign keys / `Reference[T]` are no longer dynamically subclassed.
- **Generic origin models are skipped during initialization**: a generic origin (`class M(AtomicRedisModel, Generic[T])` with unbound type params) is no longer registered/initialized. The query-expression attributes installed at init would otherwise shadow the field defaults of a concrete parametrization built later. Register a concrete subclass (`class StrM(M[str])`) instead. Documented in the *Generic Models* note in the initialization docs.
- **`afetch` is no longer a marked action**: resolving a reference reads the target through its own `aget`, so the referenced model's TTL is refreshed only per that model's own read/fetch settings — the owner's key is never touched.
- **Wider redis range**: `redis>=6.0.0,<8.1.0`.
- **Coverage**: added `ADDITIONAL_READ_ACTIONS` so unmarked read actions (afetch) are excluded from the pipeline-atomicity coverage check the same way marked READ actions are.
- Changelog + version bump to `1.3.4`.

## Testing

- Full unit suite: passing.
- Full integration suite: passing.
- Full suite with `--action-coverage`: passing (2762 passed).
- Added `test_afetch_does_not_refresh_referenced_model_ttl`; reworked the FK afetch TTL tests to install the refresh wrapper on the resolved target and assert the owner key is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how generic models are initialized and clarified priority-queue fields must be declared with `exclude=True`.
* **Bug Fixes**
  * Updated `afetch()` so resolving a reference does not refresh the referenced model’s TTL via the owner’s TTL—TTL refresh follows the referenced model’s own rules.
* **Chores**
  * Expanded supported Redis range to `>=6.0.0, <8.1.0`, updated CI/tox matrices for Redis 8.0+, bumped the package version to 1.3.4, and refreshed GitHub Actions versions.
  * Simplified typed/foreign-key field handling by reducing dynamic typed subclassing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->