### PR TITLE
v1.3.6: Cascade reach through special-field references (RedisSet/RedisPriorityQueue of ForeignKey)

### DIFF
--- a/docs/documentation/special-fields/ttl-cascade.md
+++ b/docs/documentation/special-fields/ttl-cascade.md
@@ -18,6 +18,11 @@ propagation of the parent's TTL value onto its children — a child with a short
     (`CascadeResult(0, 0)`). Non-cascade `Meta.ttl` / `refresh_ttl` behavior is
     unchanged on both backends.
 
+    This identical divergence applies to SF-held-ref cascade (`RedisSet`/
+    `RedisPriorityQueue` members): on fakeredis the container's own key still
+    refreshes via a plain `EXPIRE`, but its members are never followed — no
+    traversal, same as inline cascade.
+
 ## Enabling Cascade
 
 Cascade is opt-in and disabled by default. There are two ways to enable it:
@@ -65,6 +70,65 @@ A global default applies to every `Reference` field that has no explicit per-fie
 
 Passing `CascadeTTL(enabled=False)` on a field explicitly disables cascade for that edge
 even when a global default is set.
+
+## Cascade-Eligible Shapes
+
+Cascade traversal follows every shape a `ForeignKey` (`Reference`) can take — whether the
+reference lives inline in the parent's JSON document or inside a special-field container
+with its own Redis key:
+
+| Shape | Example | Cascade-eligible |
+|-------|---------|-------------------|
+| Direct FK field | `Reference[Author]` | Yes |
+| Collection-of-FK | `list[Reference[Author]]` / `dict[K, Reference[Author]]` | Yes |
+| Nested-submodel FK | An inline sub-model whose own field is `Reference`-annotated | Yes |
+| `RedisSet[Reference[Author]]` | FK references held as members of a Redis SET | Yes |
+| `RedisPriorityQueue[Reference[Author]]` | FK references held as members of a Redis sorted set | Yes |
+
+All five shapes resolve cascade eligibility through the same **field > global > off**
+precedence rule described above — a `RedisSet`/`RedisPriorityQueue` field is annotated
+with `CascadeTTL` exactly like an inline `Reference` field.
+
+### Worked Example: Cascading Through a `RedisSet`
+
+```python
+from typing import Annotated, ClassVar
+
+from pydantic import Field
+from rapyer import AtomicRedisModel
+from rapyer.cascade import CascadeTTL
+from rapyer.config import RedisConfig
+from rapyer.types import Reference, RedisSet
+
+
+class Author(AtomicRedisModel):
+    name: str = "anon"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+class Library(AtomicRedisModel):
+    name: str = "main"
+    authors: Annotated[RedisSet[Reference[Author]], CascadeTTL()] = Field(
+        default_factory=RedisSet
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+library = await Library(name="main").asave()
+author = await Author(name="Jane").asave()
+await library.authors.aadd(author.key)
+
+# Every member of the set is re-armed to its own Meta.ttl, exactly like an
+# inline collection-of-FK field, whenever the parent's TTL is (re)set:
+await library.asave()
+# ...or explicitly:
+await library.aset_ttl(3600, cascade=True)
+```
+
+The same applies to a `RedisPriorityQueue[Reference[Author]]` field: members added via
+`apush` are reached the same way and re-armed to their own `Meta.ttl`.
 
 ## Precedence
 

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -246,25 +246,8 @@ class AtomicRedisModel(BaseModel):
         return None
 
     @classmethod
-    def _has_cascade_enabled_sf_ref_edge(cls) -> bool:
-        # Lazy import: breaks a real planner<->scripts-package cycle at module-init.
-        from rapyer.cascade.planner import class_declares_cascade_enabled_sf_ref_edge
-
-        # cls.__dict__ (not getattr) gives each subclass its own cache slot.
-        cached = cls.__dict__.get("_cascade_sf_ref_edge_flag")
-        if cached is not None:
-            return cached
-        result = class_declares_cascade_enabled_sf_ref_edge(cls)
-        setattr(cls, "_cascade_sf_ref_edge_flag", result)
-        return result
-
-    @classmethod
     def _contains_foreign_key(cls) -> bool:
-        return bool(
-            cls._relational_field_names
-            or cls._contain_fk
-            or cls._has_cascade_enabled_sf_ref_edge()
-        )
+        return bool(cls._relational_field_names or cls._contain_fk)
 
     async def refresh_ttl(self, can_use_pipeline: bool = False):
         """Refresh TTL unconditionally."""

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -246,8 +246,25 @@ class AtomicRedisModel(BaseModel):
         return None
 
     @classmethod
+    def _has_cascade_enabled_sf_ref_edge(cls) -> bool:
+        # Lazy import: breaks a real planner<->scripts-package cycle at module-init.
+        from rapyer.cascade.planner import class_declares_cascade_enabled_sf_ref_edge
+
+        # cls.__dict__ (not getattr) gives each subclass its own cache slot.
+        cached = cls.__dict__.get("_cascade_sf_ref_edge_flag")
+        if cached is not None:
+            return cached
+        result = class_declares_cascade_enabled_sf_ref_edge(cls)
+        setattr(cls, "_cascade_sf_ref_edge_flag", result)
+        return result
+
+    @classmethod
     def _contains_foreign_key(cls) -> bool:
-        return bool(cls._relational_field_names or cls._contain_fk)
+        return bool(
+            cls._relational_field_names
+            or cls._contain_fk
+            or cls._has_cascade_enabled_sf_ref_edge()
+        )
 
     async def refresh_ttl(self, can_use_pipeline: bool = False):
         """Refresh TTL unconditionally."""

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -246,8 +246,14 @@ class AtomicRedisModel(BaseModel):
         return None
 
     @classmethod
-    def _contains_foreign_key(cls) -> bool:
-        return bool(cls._relational_field_names or cls._contain_fk)
+    def _needs_cascade_script(cls) -> bool:
+        # Any FK edge or special-field key needs the script; plain scalars use EXPIRE.
+        return bool(
+            cls._relational_field_names
+            or cls._contain_fk
+            or cls._special_field_names
+            or cls._contain_sf
+        )
 
     async def refresh_ttl(self, can_use_pipeline: bool = False):
         """Refresh TTL unconditionally."""
@@ -256,7 +262,7 @@ class AtomicRedisModel(BaseModel):
         pipe_context = ensure_pipeline if can_use_pipeline else pipeline_with_execution
         async with pipe_context(self.Meta) as pipe:
             # Native-EXPIRE fast path on fakeredis or when there is no graph to walk.
-            if self.Meta.is_fake_redis or not self._contains_foreign_key():
+            if self.Meta.is_fake_redis or not self._needs_cascade_script():
                 for key in self.all_keys:
                     pipe.expire(key, self.Meta.ttl)
                 return None
@@ -608,7 +614,7 @@ class AtomicRedisModel(BaseModel):
         in_outer_pipe = _context_pipe.get() is not None
         async with ensure_pipeline(self.Meta, should_execute=False) as pipe:
             # Native-EXPIRE fast path on fakeredis or when there is no graph to walk.
-            if self.Meta.is_fake_redis or not self._contains_foreign_key():
+            if self.Meta.is_fake_redis or not self._needs_cascade_script():
                 for key in self.all_keys:
                     pipe.expire(key, ttl)
                 if in_outer_pipe:

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -195,6 +195,48 @@ def _static_walk_fk_edges(model_cls: Any, parent_path: str, fks: list[CascadeEdg
         )
 
 
+def _static_walk_sf_fk_edges(model_cls: Any, fks: list[CascadeEdge]):
+    """
+    Append a distinct edge for each SF-held-ref field (RedisSet/RedisPriorityQueue
+    wrapping a Reference[T]) directly on model_cls. Complementary to, not a
+    replacement for, the refresh-only suffix _static_walk_special_suffixes emits
+    for the same field.
+    """
+    # Lazy import: priority_queue -> special -> scripts.loader -> planner is a real cycle.
+    from rapyer.types.priority_queue import RedisPriorityQueue
+    from rapyer.types.redis_set import RedisSet
+
+    for field_name in model_cls._special_field_names:
+        annotation = model_cls.model_fields[field_name].annotation
+        target_cls = _unwrap_relational_target(annotation)
+        if target_cls is None:
+            continue
+        stripped = strip_optional(annotation)
+        origin = get_origin(stripped) or stripped
+        if safe_issubclass(origin, RedisSet):
+            sf_container = "set"
+        elif safe_issubclass(origin, RedisPriorityQueue):
+            sf_container = "zset"
+        else:
+            continue
+        edge = _classify_edge(model_cls, field_name)
+        if not edge.enabled:
+            continue
+        fks.append(
+            CascadeEdge(
+                path=field_name,
+                target=target_cls.__name__,
+                is_collection=True,
+                recurse_into_target=True,
+                refresh_target_ttl=True,
+                refresh_target_special_keys=True,
+                resets_depth_budget=edge.override,
+                depth=edge.depth,
+                sf_container=sf_container,
+            )
+        )
+
+
 def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list[str]:
     """
     Derive the dotted-path special-field suffixes for model_cls, recursing
@@ -239,6 +281,7 @@ def build_cascade_plan(
     for model_cls in models:
         fks: list[CascadeEdge] = []
         _static_walk_fk_edges(model_cls, "$", fks)
+        _static_walk_sf_fk_edges(model_cls, fks)
         plan[model_cls.__name__] = CascadePlanEntry(
             ttl=model_cls.Meta.ttl,
             special_suffixes=_static_walk_special_suffixes(model_cls),

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -157,13 +157,18 @@ def _unwrap_nested_model_cls(annotation: Any) -> Any | None:
     return origin if safe_issubclass(origin, AtomicRedisModel) else None
 
 
-def _static_walk_fk_edges(model_cls: Any, parent_path: str, fks: list[CascadeEdge]):
+def _static_walk_fk_edges(
+    model_cls: Any, parent_path: str, fks: list[CascadeEdge], top_level: bool = True
+):
     """
     Append every enabled FK edge reachable from model_cls's own fields.
 
     Direct and collection FK fields become edges here; nested inline sub-models
-    are walked recursively. Each edge carries its own declared depth (field
-    override else global else unbounded).
+    are walked recursively; SF-held refs (RedisSet/RedisPriorityQueue of a
+    Reference) become sf_container edges. Nested SF-held-ref traversal is
+    deferred, so the SF branch fires for direct (top_level) fields only. Each
+    edge carries its own declared depth (field override else global else
+    unbounded).
     """
     for field_name in model_cls._relational_field_names:
         edge = _classify_edge(model_cls, field_name)
@@ -192,14 +197,38 @@ def _static_walk_fk_edges(model_cls: Any, parent_path: str, fks: list[CascadeEdg
         annotation = model_cls.model_fields[field_name].annotation
         nested_cls = _unwrap_nested_model_cls(annotation)
         if nested_cls is not None:
-            # Nested inline sub-model: same RedisJSON document, zero-hop
-            # recursion; the marker lives on the nested class's own field.
+            # Nested inline sub-model: same RedisJSON document, zero-hop recursion.
             nested_path = f"{parent_path}.{field_name}"
-            _static_walk_fk_edges(nested_cls, nested_path, fks)
+            _static_walk_fk_edges(nested_cls, nested_path, fks, top_level=False)
             continue
 
-        # Collection of FK: the marker lives on the collection field itself;
-        # one edge covers every element.
+        sf_container = _sf_container_kind(annotation)
+        if sf_container is not None:
+            # Nested SF-held-ref traversal is deferred; direct fields only.
+            if not top_level:
+                continue
+            edge = _classify_edge(model_cls, field_name)
+            if not edge.enabled:
+                continue
+            target_cls = _unwrap_relational_target(annotation)
+            if target_cls is None:
+                continue
+            fks.append(
+                CascadeEdge(
+                    path=field_name,
+                    target=target_cls.__name__,
+                    is_collection=True,
+                    recurse_into_target=True,
+                    refresh_target_ttl=True,
+                    refresh_target_special_keys=True,
+                    resets_depth_budget=edge.override,
+                    depth=edge.depth,
+                    sf_container=sf_container,
+                )
+            )
+            continue
+
+        # Collection of FK: one edge covers every element.
         edge = _classify_edge(model_cls, field_name)
         if not edge.enabled:
             continue
@@ -220,68 +249,19 @@ def _static_walk_fk_edges(model_cls: Any, parent_path: str, fks: list[CascadeEdg
         )
 
 
-def _static_walk_sf_fk_edges(model_cls: Any, fks: list[CascadeEdge]):
-    """
-    Append a distinct edge for each SF-held-ref field (RedisSet/RedisPriorityQueue
-    wrapping a Reference[T]) declared directly on model_cls. Complementary to, not
-    a replacement for, the refresh-only suffix _static_walk_special_suffixes emits
-    for the same field.
-
-    Scope: direct fields only. Unlike _static_walk_special_suffixes, this pass does
-    NOT recurse into nested inline sub-models, so an SF-held ref inside a nested
-    sub-model gets its refresh suffix but no traversal edge. Extending traversal to
-    the nested case is deferred to the server-side traversal work.
-    """
+def _sf_container_kind(annotation: Any) -> str | None:
+    """Return "set"/"zset" if annotation is a RedisSet/RedisPriorityQueue, else None."""
     # Lazy import: priority_queue -> special -> scripts.loader -> planner is a real cycle.
     from rapyer.types.priority_queue import RedisPriorityQueue
     from rapyer.types.redis_set import RedisSet
 
-    for field_name in model_cls._special_field_names:
-        annotation = model_cls.model_fields[field_name].annotation
-        target_cls = _unwrap_relational_target(annotation)
-        if target_cls is None:
-            continue
-        stripped = strip_optional(annotation)
-        origin = get_origin(stripped) or stripped
-        if safe_issubclass(origin, RedisSet):
-            sf_container = "set"
-        elif safe_issubclass(origin, RedisPriorityQueue):
-            sf_container = "zset"
-        else:
-            continue
-        edge = _classify_edge(model_cls, field_name)
-        if not edge.enabled:
-            continue
-        fks.append(
-            CascadeEdge(
-                path=field_name,
-                target=target_cls.__name__,
-                is_collection=True,
-                recurse_into_target=True,
-                refresh_target_ttl=True,
-                refresh_target_special_keys=True,
-                resets_depth_budget=edge.override,
-                depth=edge.depth,
-                sf_container=sf_container,
-            )
-        )
-
-
-def class_declares_cascade_enabled_sf_ref_edge(model_cls: Any) -> bool:
-    """
-    True if model_cls declares at least one cascade-enabled SF-held-ref edge
-    (an FK reference held inside a RedisSet/RedisPriorityQueue field, per the
-    same field>global>off precedence build_cascade_plan bakes into the Lua
-    plan table).
-
-    Reuses _static_walk_sf_fk_edges's classification verbatim rather than a
-    bare structural "is this a RedisSet-of-ForeignKey?" check, so a
-    cascade-disabled SF-of-FK model (e.g. a per-field CascadeTTL(enabled=False)
-    opt-out) correctly returns False here too.
-    """
-    fks: list[CascadeEdge] = []
-    _static_walk_sf_fk_edges(model_cls, fks)
-    return any(edge.sf_container is not None for edge in fks)
+    stripped = strip_optional(annotation)
+    origin = get_origin(stripped) or stripped
+    if safe_issubclass(origin, RedisSet):
+        return "set"
+    if safe_issubclass(origin, RedisPriorityQueue):
+        return "zset"
+    return None
 
 
 def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list[str]:
@@ -328,7 +308,6 @@ def build_cascade_plan(
     for model_cls in models:
         fks: list[CascadeEdge] = []
         _static_walk_fk_edges(model_cls, "$", fks)
-        _static_walk_sf_fk_edges(model_cls, fks)
         plan[model_cls.__name__] = CascadePlanEntry(
             ttl=model_cls.Meta.ttl,
             special_suffixes=_static_walk_special_suffixes(model_cls),

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -198,9 +198,14 @@ def _static_walk_fk_edges(model_cls: Any, parent_path: str, fks: list[CascadeEdg
 def _static_walk_sf_fk_edges(model_cls: Any, fks: list[CascadeEdge]):
     """
     Append a distinct edge for each SF-held-ref field (RedisSet/RedisPriorityQueue
-    wrapping a Reference[T]) directly on model_cls. Complementary to, not a
-    replacement for, the refresh-only suffix _static_walk_special_suffixes emits
+    wrapping a Reference[T]) declared directly on model_cls. Complementary to, not
+    a replacement for, the refresh-only suffix _static_walk_special_suffixes emits
     for the same field.
+
+    Scope: direct fields only. Unlike _static_walk_special_suffixes, this pass does
+    NOT recurse into nested inline sub-models, so an SF-held ref inside a nested
+    sub-model gets its refresh suffix but no traversal edge. Extending traversal to
+    the nested case is deferred to the server-side traversal work.
     """
     # Lazy import: priority_queue -> special -> scripts.loader -> planner is a real cycle.
     from rapyer.types.priority_queue import RedisPriorityQueue

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -26,20 +26,11 @@ def _field_cascade_spec(model_cls: Any, field_name: str) -> CascadeTTL | None:
 
 
 def _resolve_forward_ref(forward_ref: ForwardRef) -> Any | None:
-    """Resolve a (self-)referencing FK target baked into an SF container's
-    dynamic subclass generic args at class-body execution time.
-
-    Pydantic's ``model_rebuild(force=True)`` only re-evaluates its own
-    top-level field annotations, never the opaque generic alias baked into an
-    ``__init_subclass__``-generated ``BaseRedisType`` subclass's
-    ``__orig_bases__`` (see ``RedisConverter._build_redis_subclass``), so a
-    forward ref inside e.g. ``RedisSet[Reference["Self"]]`` stays unresolved
-    after rebuild. Every registered model name is unique, so a lookup by
-    name against the global registry stands in for pydantic's own mechanism.
-    """
-    # Lazy import: avoids any risk of a cycle back into rapyer.cascade.planner.
+    """Resolve a forward-ref FK target to its model class, or None."""
+    # Lazy import avoids a cycle back into rapyer.cascade.planner.
     from rapyer.base import REDIS_MODELS
 
+    # model_rebuild leaves SF-container forward refs unresolved, so match by name in the registry.
     name = forward_ref.__forward_arg__
     for model in REDIS_MODELS:
         if model.__name__ == name:
@@ -66,39 +57,20 @@ def _unwrap_relational_target(annotation: Any) -> Any | None:
 
 @dataclasses.dataclass(frozen=True)
 class CascadeEdge:
-    """
-    One FK edge out of a class in the cascade plan table.
-
-    depth=None means unbounded; cascade_plan_json drops None-valued fields, so
-    the per-call plan JSON carries no depth key for these.
-
-    recurse_into_target / refresh_target_ttl / refresh_target_special_keys are
-    always True today: every edge the planner currently emits follows the
-    target, refreshes its ttl, and refreshes its special keys. They are
-    forward-looking per-edge hooks for future delete/save-cascade work — the
-    Lua keeps a documented dead branch for the non-recursing case so it is
-    ready when a planner-side reason to set them False shows up.
-    resets_depth_budget means an explicit per-field CascadeTTL() spec resets
-    the child's depth budget to this edge's own depth instead of decrementing
-    the budget inherited from the parent.
-
-    sf_container is None for an inline edge (direct/collection/nested). It is
-    "set" / "zset" when the FK reference is held inside a RedisSet /
-    RedisPriorityQueue special-field container instead of inline in the
-    parent's JSON document. For an SF edge, path holds the SF key suffix (the
-    dotted form used to build __rapyer_special__:{model_key}:{suffix}), NOT a
-    $.-rooted JSONPath — Phase-2 Lua branches on sf_container to read via
-    SMEMBERS/ZRANGE instead of the inline JSON.GET batch.
-    """
+    """One FK edge out of a class in the cascade plan table."""
 
     path: str
     target: str
     is_collection: bool
+    # Always True today; forward-looking hooks for future delete/save-cascade work.
     recurse_into_target: bool
     refresh_target_ttl: bool
     refresh_target_special_keys: bool
+    # A per-field CascadeTTL() resets the child's budget to this depth, not decrement the parent's.
     resets_depth_budget: bool
+    # None means unbounded; cascade_plan_json drops it from the per-call JSON.
     depth: int | None = None
+    # None = inline; "set"/"zset" = FK held in a RedisSet/PQ, path is then the SF key suffix.
     sf_container: str | None = None
 
 
@@ -107,20 +79,14 @@ class CascadePlanEntry:
     """One class's full entry in the cascade plan table."""
 
     ttl: int | None
-    # Special fields live under their own Redis key (SF: RedisSet,
-    # RedisPriorityQueue), separate from the main JSON document; the Lua must
-    # EXPIRE each of these suffixed keys alongside the main key whenever it
-    # refreshes this class's key.
+    # SF keys (RedisSet/PQ) live under their own suffixed keys, EXPIREd alongside the main key.
     special_suffixes: list[str]
     fks: list[CascadeEdge]
 
 
 @dataclasses.dataclass(frozen=True)
 class EdgeClassification:
-    """
-    Result of classifying a single FK-shaped field: enabled, its depth, and
-    whether an explicit per-field spec overrode the global default.
-    """
+    """Whether an FK field cascades, its depth, and if a per-field spec overrode the global."""
 
     enabled: bool
     depth: int | None
@@ -148,8 +114,7 @@ def _resolve_target_cls(model_cls: Any, field_name: str) -> Any | None:
 
 def _unwrap_nested_model_cls(annotation: Any) -> Any | None:
     """Return the class if annotation is a nested inline sub-model, else None."""
-    # Lazy import: rapyer.base imports rapyer.cascade at module level, so a
-    # top-level import here would create a cycle.
+    # Lazy import breaks the rapyer.base -> rapyer.cascade module cycle.
     from rapyer.base import AtomicRedisModel
 
     stripped = strip_optional(annotation)
@@ -160,16 +125,7 @@ def _unwrap_nested_model_cls(annotation: Any) -> Any | None:
 def _static_walk_fk_edges(
     model_cls: Any, parent_path: str, fks: list[CascadeEdge], top_level: bool = True
 ):
-    """
-    Append every enabled FK edge reachable from model_cls's own fields.
-
-    Direct and collection FK fields become edges here; nested inline sub-models
-    are walked recursively; SF-held refs (RedisSet/RedisPriorityQueue of a
-    Reference) become sf_container edges. Nested SF-held-ref traversal is
-    deferred, so the SF branch fires for direct (top_level) fields only. Each
-    edge carries its own declared depth (field override else global else
-    unbounded).
-    """
+    """Append every enabled FK edge reachable from model_cls's own fields."""
     for field_name in model_cls._relational_field_names:
         edge = _classify_edge(model_cls, field_name)
         if not edge.enabled:
@@ -177,9 +133,7 @@ def _static_walk_fk_edges(
         target_cls = _resolve_target_cls(model_cls, field_name)
         if target_cls is None:
             continue
-        # An explicit per-field spec is a whole-object override: the Lua
-        # traversal refreshes the child's budget to this edge's depth. A blanket
-        # global edge decrements/caps the inherited budget instead.
+        # A per-field spec resets the child's budget to this depth; a global edge decrements it.
         fks.append(
             CascadeEdge(
                 path=f"{parent_path}.{field_name}",
@@ -265,10 +219,7 @@ def _sf_container_kind(annotation: Any) -> str | None:
 
 
 def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list[str]:
-    """
-    Derive the dotted-path special-field suffixes for model_cls, recursing
-    into nested sub-models that themselves hold special fields.
-    """
+    """Dotted-path special-field suffixes for model_cls, recursing into nested sub-models."""
     from rapyer.base import AtomicRedisModel
 
     suffixes: list[str] = []
@@ -277,14 +228,10 @@ def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list
         suffixes.append(field_path.lstrip("."))
     for field_name in model_cls._contain_sf:
         annotation = model_cls.model_fields[field_name].annotation
-        # Unwrap Optional[...]/generic origins the same way
-        # _unwrap_nested_model_cls does, so a nested model hidden behind
-        # Optional[...] or a generic alias is still recognized.
+        # Unwrap Optional/generic origins so a nested model behind them is still recognized.
         stripped = strip_optional(annotation)
         field_cls = get_origin(stripped) or stripped
-        # Container-of-special-field shapes (e.g. list[RedisSet]) have no
-        # per-class suffix set to enumerate; only nested models with their own
-        # special fields do.
+        # Only nested models have a per-class suffix set; container-of-SF (list[RedisSet]) don't.
         if not safe_issubclass(field_cls, AtomicRedisModel):
             continue
         if not field_cls.contains_sf_field():
@@ -297,13 +244,7 @@ def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list
 def build_cascade_plan(
     models: list[type["AtomicRedisModel"]],
 ) -> dict[str, CascadePlanEntry]:
-    """
-    Build the static, per-class cascade plan table baked into the Lua script.
-
-    Every model gets one entry keyed by its class name, covering its FK edges,
-    special-field suffixes, and own Meta.ttl. Pure annotation introspection;
-    never hydrates an instance or touches Redis.
-    """
+    """Build the static, per-class cascade plan table baked into the Lua script."""
     plan: dict[str, CascadePlanEntry] = {}
     for model_cls in models:
         fks: list[CascadeEdge] = []
@@ -317,20 +258,11 @@ def build_cascade_plan(
 
 
 def validate_cascade_ttl_targets(plan: dict[str, CascadePlanEntry]):
-    """
-    Raise CascadeTargetTtlMissingError when a cascade participant lacks a ttl.
-
-    The Lua write phase EXPIREs every reached key with its owning class's ttl, so
-    a None ttl would become a nil-arg runtime error. Both an edge's target and a
-    cascade root (a class with outgoing edges) refresh their own key and so must
-    declare a ttl. Target violations are checked first to keep a stable,
-    deterministic first-violation order.
-    """
+    """Raise CascadeTargetTtlMissingError when a cascade participant lacks a Meta.ttl."""
     for class_name, entry in sorted(plan.items()):
         for edge in entry.fks:
             target = edge.target
-            # A partial plan (a subset of models) may omit an edge's target;
-            # surface a RapyerError rather than a bare KeyError.
+            # A partial plan may omit a target; surface a RapyerError, not a bare KeyError.
             target_entry = plan.get(target)
             if target_entry is None:
                 raise CascadeTargetTtlMissingError(
@@ -371,12 +303,7 @@ def _drop_none_values(value: Any) -> Any:
 
 
 def cascade_plan_json(plan: dict[str, CascadePlanEntry]) -> str:
-    """
-    Serialize the full cascade plan to compact JSON.
-
-    The result is written once to a Redis key at init_rapyer and read
-    server-side by the Lua on every call, rather than shipped per call.
-    """
+    """Serialize the full cascade plan to compact JSON."""
     payload = {
         name: _drop_none_values(dataclasses.asdict(entry))
         for name, entry in plan.items()
@@ -391,13 +318,7 @@ def cascade_plan_hash(plan_json: str) -> str:
 
 def cascade_names(plan_json: str) -> tuple[str, str]:
     """Deterministic (library_name, function_name) for a plan, both carrying the plan hash."""
-    # Redis Function NAMES are server-GLOBAL, not per-library: two libraries
-    # cannot both register a function named "cascade_apply" (the second FUNCTION
-    # LOAD errors). Baking the plan hash into BOTH the library AND the function
-    # name lets two rapyer processes with different model sets (e.g. CI workers)
-    # coexist on one server instead of clobbering each other's baked plan;
-    # identical plans hash-collide to the same names so FUNCTION LOAD REPLACE is
-    # idempotent. FCALL therefore targets the hashed function name.
+    # Hash in both names avoids server-global Redis Function name clashes across processes.
     plan_hash = cascade_plan_hash(plan_json)
     return (
         f"{CASCADE_LIBRARY_PREFIX}_{plan_hash}",
@@ -407,9 +328,7 @@ def cascade_names(plan_json: str) -> tuple[str, str]:
 
 def cascade_plan_lua_literal(plan_json: str) -> str:
     """Wrap the compact plan JSON in a Lua long-bracket literal so it embeds verbatim."""
-    # The plan JSON is identifier/path/suffix data only (class names, dotted
-    # $-paths, special-field suffixes) — none can contain ]==]. Guard anyway
-    # rather than trust that invariant, since this bakes into executable source.
+    # Plan JSON is identifier/path data only, but guard anyway since this bakes into source.
     if "]==]" in plan_json:
         raise CascadeLuaLiteralError(
             "cascade plan JSON contains the Lua long-bracket delimiter ']==]', "

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -1,7 +1,7 @@
 import dataclasses
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, get_origin
+from typing import TYPE_CHECKING, Any, ForwardRef, get_origin
 
 from rapyer.cascade.ttl import CascadeTTL
 from rapyer.errors.cascade import CascadeLuaLiteralError, CascadeTargetTtlMissingError
@@ -25,13 +25,38 @@ def _field_cascade_spec(model_cls: Any, field_name: str) -> CascadeTTL | None:
     return None
 
 
+def _resolve_forward_ref(forward_ref: ForwardRef) -> Any | None:
+    """Resolve a (self-)referencing FK target baked into an SF container's
+    dynamic subclass generic args at class-body execution time.
+
+    Pydantic's ``model_rebuild(force=True)`` only re-evaluates its own
+    top-level field annotations, never the opaque generic alias baked into an
+    ``__init_subclass__``-generated ``BaseRedisType`` subclass's
+    ``__orig_bases__`` (see ``RedisConverter._build_redis_subclass``), so a
+    forward ref inside e.g. ``RedisSet[Reference["Self"]]`` stays unresolved
+    after rebuild. Every registered model name is unique, so a lookup by
+    name against the global registry stands in for pydantic's own mechanism.
+    """
+    # Lazy import: avoids any risk of a cycle back into rapyer.cascade.planner.
+    from rapyer.base import REDIS_MODELS
+
+    name = forward_ref.__forward_arg__
+    for model in REDIS_MODELS:
+        if model.__name__ == name:
+            return model
+    return None
+
+
 def _unwrap_relational_target(annotation: Any) -> Any | None:
     """Return the model class an FK-shaped annotation points to, or None."""
     stripped = strip_optional(annotation)
     origin = get_origin(stripped) or stripped
     if safe_issubclass(origin, RelationalFieldType):
         args = resolve_generic_args(stripped)
-        return args[0] if args else None
+        target = args[0] if args else None
+        if isinstance(target, ForwardRef):
+            return _resolve_forward_ref(target)
+        return target
     for arg in resolve_generic_args(stripped):
         found = _unwrap_relational_target(arg)
         if found is not None:

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -267,6 +267,23 @@ def _static_walk_sf_fk_edges(model_cls: Any, fks: list[CascadeEdge]):
         )
 
 
+def class_declares_cascade_enabled_sf_ref_edge(model_cls: Any) -> bool:
+    """
+    True if model_cls declares at least one cascade-enabled SF-held-ref edge
+    (an FK reference held inside a RedisSet/RedisPriorityQueue field, per the
+    same field>global>off precedence build_cascade_plan bakes into the Lua
+    plan table).
+
+    Reuses _static_walk_sf_fk_edges's classification verbatim rather than a
+    bare structural "is this a RedisSet-of-ForeignKey?" check, so a
+    cascade-disabled SF-of-FK model (e.g. a per-field CascadeTTL(enabled=False)
+    opt-out) correctly returns False here too.
+    """
+    fks: list[CascadeEdge] = []
+    _static_walk_sf_fk_edges(model_cls, fks)
+    return any(edge.sf_container is not None for edge in fks)
+
+
 def _static_walk_special_suffixes(model_cls: Any, parent_path: str = "") -> list[str]:
     """
     Derive the dotted-path special-field suffixes for model_cls, recursing

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -56,6 +56,14 @@ class CascadeEdge:
     resets_depth_budget means an explicit per-field CascadeTTL() spec resets
     the child's depth budget to this edge's own depth instead of decrementing
     the budget inherited from the parent.
+
+    sf_container is None for an inline edge (direct/collection/nested). It is
+    "set" / "zset" when the FK reference is held inside a RedisSet /
+    RedisPriorityQueue special-field container instead of inline in the
+    parent's JSON document. For an SF edge, path holds the SF key suffix (the
+    dotted form used to build __rapyer_special__:{model_key}:{suffix}), NOT a
+    $.-rooted JSONPath — Phase-2 Lua branches on sf_container to read via
+    SMEMBERS/ZRANGE instead of the inline JSON.GET batch.
     """
 
     path: str
@@ -66,6 +74,7 @@ class CascadeEdge:
     refresh_target_special_keys: bool
     resets_depth_budget: bool
     depth: int | None = None
+    sf_container: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/rapyer/scripts/lua/cascade/library.lua
+++ b/rapyer/scripts/lua/cascade/library.lua
@@ -234,13 +234,19 @@ local function cascade_apply(keys, args)
         if not edge.recurse_into_target then
             budget = 0
         end
+        -- redis.pcall (unlike redis.call) returns an error table instead of
+        -- raising on a Redis-level error such as WRONGTYPE -- a corrupt SF
+        -- container key becomes a dead end (no members) for this edge only,
+        -- not an aborted cascade, matching read_reference_paths' contract.
         local sf_key = special_prefix .. ':' .. parent_key .. ':' .. edge.path
-        local members
+        local raw_members
         if edge.sf_container == 'set' then
-            members = redis.call('SMEMBERS', sf_key)
+            raw_members = redis.pcall('SMEMBERS', sf_key)
         else
-            members = redis.call('ZRANGE', sf_key, 0, -1)
+            raw_members = redis.pcall('ZRANGE', sf_key, 0, -1)
         end
+        local members = (type(raw_members) == 'table' and raw_members.err == nil)
+            and raw_members or {}
         for _, raw_member in ipairs(members) do
             -- A malformed (non-JSON) or non-string-decoded member is a dead
             -- end for that member only -- never aborts the atomic FCALL.

--- a/rapyer/scripts/lua/cascade/library.lua
+++ b/rapyer/scripts/lua/cascade/library.lua
@@ -223,6 +223,34 @@ local function cascade_apply(keys, args)
         end
     end
 
+    -- SF-held-ref edge: read the field's own SET/ZSET key (not the inline
+    -- JSON document) and feed each decoded member through push_child.
+    -- next_hop is called ONCE per edge here, never per member.
+    local function push_sf_edge(parent_key, edge, remaining_budget, established)
+        local follow, budget = next_hop(edge, remaining_budget, established)
+        if not follow then
+            return
+        end
+        if not edge.recurse_into_target then
+            budget = 0
+        end
+        local sf_key = special_prefix .. ':' .. parent_key .. ':' .. edge.path
+        local members
+        if edge.sf_container == 'set' then
+            members = redis.call('SMEMBERS', sf_key)
+        else
+            members = redis.call('ZRANGE', sf_key, 0, -1)
+        end
+        for _, raw_member in ipairs(members) do
+            -- A malformed (non-JSON) or non-string-decoded member is a dead
+            -- end for that member only -- never aborts the atomic FCALL.
+            local ok, target_key = pcall(cjson.decode, raw_member)
+            if ok and type(target_key) == 'string' then
+                push_child(target_key, edge, budget)
+            end
+        end
+    end
+
     -- Worklist of (key, class, budget, established) frames: budget is the number
     -- of remaining BLANKET hops still allowed out of `key` (UNBOUNDED = no cap),
     -- and established marks whether `key`'s subtree was already entered via
@@ -236,12 +264,21 @@ local function cascade_apply(keys, args)
             return  -- no reference paths to read for this class
         end
         local paths = {}
+        local inline_edges = {}
         for _, edge in ipairs(edges) do
-            paths[#paths + 1] = edge.path
+            if edge.sf_container then
+                push_sf_edge(parent_key, edge, remaining_budget, established)
+            else
+                paths[#paths + 1] = edge.path
+                inline_edges[#inline_edges + 1] = edge
+            end
         end
-        -- One JSON.GET reads every edge path of this node, not one per edge.
+        if #paths == 0 then
+            return  -- every edge on this class was SF-held; no inline JSON.GET needed
+        end
+        -- One JSON.GET reads every inline edge path of this node, not one per edge.
         local values_by_path = read_reference_paths(parent_key, paths)
-        for _, edge in ipairs(edges) do
+        for _, edge in ipairs(inline_edges) do
             local matched = values_by_path[edge.path]
             if matched ~= nil then
                 local follow, budget = next_hop(edge, remaining_budget, established)

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar, get_origin
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -9,7 +9,7 @@ from rapyer.actions import ActionGroup, mark_actions
 from rapyer.errors.base import RapyerSerializationError
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME
 from rapyer.types.special import SpecialFieldType
-from rapyer.utils.pythonic import resolve_generic_args
+from rapyer.utils.pythonic import resolve_generic_args, safe_issubclass
 
 T = TypeVar("T")
 
@@ -26,6 +26,18 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
     """
 
     LUA_SNIPPET_DIR = "redis_priority_queue"
+
+    @classmethod
+    def contains_fk_field(cls) -> bool:
+        """True when this queue's member type is a foreign-key reference."""
+        from rapyer.types.relational import RelationalFieldType
+
+        args = resolve_generic_args(cls)
+        inner = args[0] if args else Any
+        if inner is Any:
+            return False
+        inner = get_origin(inner) or inner
+        return safe_issubclass(inner, RelationalFieldType)
 
     # --- Serialization helpers ---
 

--- a/rapyer/types/priority_queue.py
+++ b/rapyer/types/priority_queue.py
@@ -30,8 +30,12 @@ class RedisPriorityQueue(SpecialFieldType, Generic[T]):
     # --- Serialization helpers ---
 
     def _dump_members(self, values) -> list[str]:
+        # dump_python never validates, so coerce raw input (e.g. an FK key string) first.
+        validated = self._adapter.validate_python(
+            list(values), context={REDIS_DUMP_FLAG_NAME: True}
+        )
         serialized = self._adapter.dump_python(
-            list(values), mode="json", context={REDIS_DUMP_FLAG_NAME: True}
+            validated, mode="json", context={REDIS_DUMP_FLAG_NAME: True}
         )
         return [json.dumps(s) for s in serialized]
 

--- a/rapyer/types/redis_set.py
+++ b/rapyer/types/redis_set.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Any, Generic, Iterable, Optional, TypeVar
+from typing import Any, Generic, Iterable, Optional, TypeVar, get_origin
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -8,7 +8,7 @@ from pydantic_core import core_schema
 from rapyer.actions import ActionGroup, mark_actions
 from rapyer.types.base import REDIS_DUMP_FLAG_NAME
 from rapyer.types.special import SpecialFieldType
-from rapyer.utils.pythonic import resolve_generic_args
+from rapyer.utils.pythonic import resolve_generic_args, safe_issubclass
 
 T = TypeVar("T")
 
@@ -24,6 +24,18 @@ class RedisSet(set, SpecialFieldType, Generic[T]):
     def __init__(self, *args, **kwargs):
         set.__init__(self, *args, **kwargs)
         SpecialFieldType.__init__(self)
+
+    @classmethod
+    def contains_fk_field(cls) -> bool:
+        """True when this set's member type is a foreign-key reference."""
+        from rapyer.types.relational import RelationalFieldType
+
+        args = resolve_generic_args(cls)
+        inner = args[0] if args else Any
+        if inner is Any:
+            return False
+        inner = get_origin(inner) or inner
+        return safe_issubclass(inner, RelationalFieldType)
 
     # --- Serialization helpers ---
 

--- a/rapyer/types/redis_set.py
+++ b/rapyer/types/redis_set.py
@@ -28,8 +28,10 @@ class RedisSet(set, SpecialFieldType, Generic[T]):
     # --- Serialization helpers ---
 
     def _dump_members(self, values: Iterable[T]) -> list[str]:
+        # dump_python never validates, so coerce raw input (e.g. an FK key string) first.
+        validated = self._adapter.validate_python(set(values))
         return self._adapter.dump_python(
-            set(values), mode="json", context={REDIS_DUMP_FLAG_NAME: True}
+            validated, mode="json", context={REDIS_DUMP_FLAG_NAME: True}
         )
 
     def _dump_member(self, value: T) -> str:

--- a/tests/action_groups.py
+++ b/tests/action_groups.py
@@ -68,7 +68,7 @@ PRIVATE_METHODS = _group(
     AtomicRedisModel._iter_special_fields,
     AtomicRedisModel._ttl_keys,
     # Pure in-memory FK-field check gating the TTL cascade fast path; no Redis.
-    AtomicRedisModel._contains_foreign_key,
+    AtomicRedisModel._needs_cascade_script,
     AtomicRedisModel.class_key_initials,
     AtomicRedisModel.index_name,
     AtomicRedisModel.create_expressions,

--- a/tests/action_groups.py
+++ b/tests/action_groups.py
@@ -45,6 +45,8 @@ PRIVATE_METHODS = _group(
     # Generic
     GenericRedisType.contains_sf_field,
     GenericRedisType.contains_fk_field,
+    RedisSet.contains_fk_field,
+    RedisPriorityQueue.contains_fk_field,
     # AtomicRedisModel
     AtomicRedisModel._search_keys_by_query,
     AtomicRedisModel.build_redis_model,

--- a/tests/integration/foreign_keys/conftest.py
+++ b/tests/integration/foreign_keys/conftest.py
@@ -6,6 +6,7 @@ from rapyer.cascade.planner import (
 )
 from rapyer.scripts import register_cascade_function, register_scripts
 from rapyer.types.relational import resolve_relational_targets
+from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
 from tests.models.cascade_types import ALL_CASCADE_MODELS
 from tests.models.foreign_key_types import FkAuthor, FkBook, FkPublisher
 
@@ -47,6 +48,18 @@ async def setup_real_redis_for_cascade_apply(
         model.Meta.redis = original_redis
         model.Meta.is_fake_redis = original_is_fake
         model.Meta.cascade_function_name = original_function_name
+
+
+async def apply_cascade(real_redis_client, root, cascade=True):
+    return await real_redis_client.fcall(
+        type(root).Meta.cascade_function_name,
+        1,
+        root.key,
+        type(root).__name__,
+        SPECIAL_FIELD_KEY_PREFIX,
+        type(root).Meta.ttl,
+        1 if cascade else 0,
+    )
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/foreign_keys/test_cascade_depth_and_gate.py
+++ b/tests/integration/foreign_keys/test_cascade_depth_and_gate.py
@@ -2,7 +2,7 @@ import pytest
 
 from rapyer.types.priority_queue import RedisPriorityQueue
 from rapyer.types.redis_set import RedisSet
-from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
     CascadeAuthor,
     CascadeBlanketLeaf,
@@ -24,18 +24,6 @@ from tests.models.cascade_types import (
 pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
 
 
-async def _apply_cascade(real_redis_client, root, cascade=True):
-    return await real_redis_client.fcall(
-        type(root).Meta.cascade_function_name,
-        1,
-        root.key,
-        type(root).__name__,
-        SPECIAL_FIELD_KEY_PREFIX,
-        type(root).Meta.ttl,
-        1 if cascade else 0,
-    )
-
-
 # --- do_cascade gate (real-Redis-only; ported from the fakeredis unit tests) ---
 
 
@@ -52,7 +40,7 @@ async def test_cascade_false_refreshes_only_root_not_the_fk_child(real_redis_cli
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, parent, cascade=False)
+    await apply_cascade(real_redis_client, parent, cascade=False)
 
     # Assert
     assert await real_redis_client.ttl(parent.key) > 0
@@ -70,7 +58,7 @@ async def test_cascade_false_still_refreshes_roots_own_special_keys(real_redis_c
     await real_redis_client.persist(child.key)
 
     # Act
-    result = await _apply_cascade(real_redis_client, child, cascade=False)
+    result = await apply_cascade(real_redis_client, child, cascade=False)
 
     # Assert
     assert await real_redis_client.ttl(child.key) > 0
@@ -100,7 +88,7 @@ async def test_cascade_counts_fully_dangling_child_and_its_special_keys(
     await real_redis_client.persist(parent.key)
 
     # Act
-    result = await _apply_cascade(real_redis_client, parent)
+    result = await apply_cascade(real_redis_client, parent)
 
     # Assert
     assert result == [1, 2]
@@ -117,7 +105,7 @@ async def test_cascade_counts_dangling_special_keys_on_an_existing_child(
     await real_redis_client.persist(child.key)
 
     # Act
-    result = await _apply_cascade(real_redis_client, parent)
+    result = await apply_cascade(real_redis_client, parent)
 
     # Assert
     assert result == [0, 2]
@@ -138,7 +126,7 @@ async def test_depth0_shallow_root_extends_via_explicit_override(real_redis_clie
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
@@ -172,7 +160,7 @@ async def test_independent_sibling_depth_budgets(real_redis_client):
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
@@ -197,7 +185,7 @@ async def test_max_budget_wins_for_shared_child_reaches_full_deep_prefix(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
@@ -217,7 +205,7 @@ async def test_nested_submodel_fk_reaches_the_targets_own_ttl(real_redis_client)
     await real_redis_client.persist(book.key)
 
     # Act
-    await _apply_cascade(real_redis_client, book)
+    await apply_cascade(real_redis_client, book)
 
     # Assert
     assert await real_redis_client.ttl(book.key) > 0
@@ -235,7 +223,7 @@ async def test_blanket_opt_out_field_stops_traversal_despite_blanket_global(
     await real_redis_client.persist(leaf.key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     assert await real_redis_client.ttl(root.key) > 0
@@ -256,7 +244,7 @@ async def test_nested_submodel_zero_hop_does_not_consume_depth_budget(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     refreshed = {
@@ -280,7 +268,7 @@ async def test_node_beyond_nested_depth_budget_is_never_reached(real_redis_clien
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     refreshed = {

--- a/tests/integration/foreign_keys/test_cascade_graph_shapes.py
+++ b/tests/integration/foreign_keys/test_cascade_graph_shapes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
     CascadeChainNode,
     CascadeChainRoot,
@@ -11,18 +11,6 @@ from tests.models.cascade_types import (
 )
 
 pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
-
-
-async def _apply_cascade(real_redis_client, root):
-    return await real_redis_client.fcall(
-        type(root).Meta.cascade_function_name,
-        1,
-        root.key,
-        type(root).__name__,
-        SPECIAL_FIELD_KEY_PREFIX,
-        type(root).Meta.ttl,
-        1,
-    )
 
 
 # --- (a) Multi-level chain ---
@@ -47,7 +35,7 @@ async def test_multi_level_chain_reaches_expected_prefix_sanity(real_redis_clien
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     # Root, a, b, c refreshed; d (beyond the depth-2 budget) untouched.
@@ -77,7 +65,7 @@ async def test_cyclic_two_node_cycle_does_not_hang_or_error_sanity(real_redis_cl
 
     # Act
     # Bounded by the visited-set; must complete without hanging/erroring.
-    await _apply_cascade(real_redis_client, a)
+    await apply_cascade(real_redis_client, a)
 
     # Assert
     assert await real_redis_client.ttl(a.key) > 0
@@ -106,7 +94,7 @@ async def test_genuine_single_node_self_loop_does_not_hang_or_error_sanity(
 
     # Act
     # Bounded by the visited-set; must complete without hanging/erroring.
-    await _apply_cascade(real_redis_client, node)
+    await apply_cascade(real_redis_client, node)
 
     # Assert
     assert await real_redis_client.ttl(node.key) > 0
@@ -133,7 +121,7 @@ async def test_diamond_shared_child_refreshed_exactly_once_via_either_edge_sanit
 
     # Act
     # Must not error from the double-visit (visited-set dedup).
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     assert await real_redis_client.ttl(root.key) > 0
@@ -163,12 +151,12 @@ async def test_shared_child_via_two_independent_roots_refreshed_from_either_root
 
     # Act
     # Apply cascade from EACH root independently.
-    await _apply_cascade(real_redis_client, root_a)
+    await apply_cascade(real_redis_client, root_a)
     assert await real_redis_client.ttl(root_a.key) > 0
     assert await real_redis_client.ttl(child.key) > 0
 
     await real_redis_client.persist(child.key)
-    await _apply_cascade(real_redis_client, root_b)
+    await apply_cascade(real_redis_client, root_b)
 
     # Assert
     # The shared child refreshes from either independent root.

--- a/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
@@ -1,0 +1,205 @@
+import pytest
+
+from rapyer.types.redis_set import RedisSet
+from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.models.cascade_types import (
+    CascadeAuthor,
+    CascadeMixedEdgeSharedChild,
+    CascadeMixedEdgeSharedChildRoot,
+    CascadePQRefParent,
+    CascadePQRefSelfNode,
+    CascadeSetRefParent,
+    CascadeSetRefSelfNode,
+    CascadeSfDiamondChild,
+    CascadeSfDiamondRoot,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
+
+
+async def _apply_cascade(real_redis_client, root):
+    return await real_redis_client.fcall(
+        type(root).Meta.cascade_function_name,
+        1,
+        root.key,
+        type(root).__name__,
+        SPECIAL_FIELD_KEY_PREFIX,
+        type(root).Meta.ttl,
+        1,
+    )
+
+
+# --- Test A (CASF-04): RedisSet[ForeignKey] reach ---
+
+
+@pytest.mark.asyncio
+async def test_set_ref_parent_reaches_and_refreshes_both_set_members(
+    real_redis_client,
+):
+    # Arrange
+    parent = await CascadeSetRefParent().asave()
+    author1 = await CascadeAuthor(name="a1").asave()
+    author2 = await CascadeAuthor(name="a2").asave()
+    await parent.refs.aadd(author1.key)
+    await parent.refs.aadd(author2.key)
+    for key in (parent.key, author1.key, author2.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    await _apply_cascade(real_redis_client, parent)
+
+    # Assert
+    assert await real_redis_client.ttl(parent.key) > 0
+    assert await real_redis_client.ttl(author1.key) > 0
+    assert await real_redis_client.ttl(author2.key) > 0
+
+
+# --- Test B (CASF-05): RedisPriorityQueue[ForeignKey] reach ---
+
+
+@pytest.mark.asyncio
+async def test_pq_ref_parent_reaches_and_refreshes_pq_member(real_redis_client):
+    # Arrange
+    parent = await CascadePQRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.queue.apush(author.key, priority=1.0)
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    await _apply_cascade(real_redis_client, parent)
+
+    # Assert
+    assert await real_redis_client.ttl(parent.key) > 0
+    assert await real_redis_client.ttl(author.key) > 0
+
+
+# --- Test C (CASF-06 dangling reuse, D-02) ---
+
+
+@pytest.mark.asyncio
+async def test_set_ref_dangling_member_reuses_existing_dangling_count(
+    real_redis_client,
+):
+    # Arrange
+    parent = await CascadeSetRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.refs.aadd(author.key)
+    await parent.refs.aadd("CascadeAuthor:does-not-exist")
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await _apply_cascade(real_redis_client, parent)
+
+    # Assert (no separate SF-dangling counter -- reuses the existing dangling shape)
+    assert result == [1, 0]
+    assert await real_redis_client.ttl(parent.key) > 0
+    assert await real_redis_client.ttl(author.key) > 0
+
+
+# --- Test D (CASF-07 self-ref in SET) ---
+
+
+@pytest.mark.asyncio
+async def test_set_ref_self_node_terminates_without_hanging(real_redis_client):
+    # Arrange
+    node = await CascadeSetRefSelfNode().asave()
+    await node.peers.aadd(node.key)
+    await real_redis_client.persist(node.key)
+
+    # Act (bounded by the shared visited map; must not hang or error)
+    await _apply_cascade(real_redis_client, node)
+
+    # Assert
+    assert await real_redis_client.ttl(node.key) > 0
+
+
+# --- Test E (CASF-07 mixed-edge max-budget-wins) ---
+
+
+@pytest.mark.asyncio
+async def test_mixed_edge_shared_child_walked_at_the_larger_sf_budget(
+    real_redis_client,
+):
+    # Arrange
+    c4 = await CascadeMixedEdgeSharedChild(name="c4").asave()
+    c3 = await CascadeMixedEdgeSharedChild(name="c3", onward=c4.key).asave()
+    c2 = await CascadeMixedEdgeSharedChild(name="c2", onward=c3.key).asave()
+    c1 = await CascadeMixedEdgeSharedChild(name="c1", onward=c2.key).asave()
+    head = await CascadeMixedEdgeSharedChild(name="head", onward=c1.key).asave()
+    root = await CascadeMixedEdgeSharedChildRoot(shallow_inline=head.key).asave()
+    await root.deep_set.aadd(head.key)
+    all_keys = (root.key, head.key, c1.key, c2.key, c3.key, c4.key)
+    for key in all_keys:
+        await real_redis_client.persist(key)
+
+    # Act
+    await _apply_cascade(real_redis_client, root)
+
+    # Assert (deep_set depth=4 SF budget wins over shallow_inline depth=1)
+    refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
+    assert refreshed == set(all_keys)
+
+
+# --- Test F (threat-model tolerance) ---
+
+
+@pytest.mark.asyncio
+async def test_malformed_and_non_string_sf_members_are_tolerated(real_redis_client):
+    # Arrange
+    parent = await CascadeSetRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.refs.aadd(author.key)
+    sf_key = RedisSet.special_field_key(parent.key, "refs")
+    await real_redis_client.sadd(sf_key, "not-json", "42")
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act (must not raise despite the malformed/non-string members)
+    await _apply_cascade(real_redis_client, parent)
+
+    # Assert
+    assert await real_redis_client.ttl(parent.key) > 0
+    assert await real_redis_client.ttl(author.key) > 0
+
+
+# --- Test G (CASF-07 self-ref in PQ/ZSET) ---
+
+
+@pytest.mark.asyncio
+async def test_pq_ref_self_node_terminates_without_hanging(real_redis_client):
+    # Arrange
+    node = await CascadePQRefSelfNode().asave()
+    await node.peers.apush(node.key, priority=1.0)
+    await real_redis_client.persist(node.key)
+
+    # Act (exercises the ZRANGE branch's cycle-safety, independent of Test D)
+    await _apply_cascade(real_redis_client, node)
+
+    # Assert
+    assert await real_redis_client.ttl(node.key) > 0
+
+
+# --- Test H (CASF-07 SF-only dual-edge diamond) ---
+
+
+@pytest.mark.asyncio
+async def test_sf_only_dual_edge_diamond_shared_child_refreshed_exactly_once(
+    real_redis_client,
+):
+    # Arrange
+    child = await CascadeSfDiamondChild().asave()
+    root = await CascadeSfDiamondRoot().asave()
+    await root.left.aadd(child.key)
+    await root.right.apush(child.key, priority=1.0)
+    for key in (root.key, child.key):
+        await real_redis_client.persist(key)
+
+    # Act (must not error from the double-visit -- visited-map dedup across SET+ZSET)
+    result = await _apply_cascade(real_redis_client, root)
+
+    # Assert
+    assert await real_redis_client.ttl(root.key) > 0
+    assert await real_redis_client.ttl(child.key) > 0
+    assert result == [0, 0]

--- a/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
@@ -1,8 +1,9 @@
 import pytest
 
 from rapyer.types.redis_set import RedisSet
-from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
+    CASCADE_FIXTURE_TTL_SECONDS,
     CascadeAuthor,
     CascadeMixedEdgeSharedChild,
     CascadeMixedEdgeSharedChildRoot,
@@ -15,18 +16,6 @@ from tests.models.cascade_types import (
 )
 
 pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
-
-
-async def _apply_cascade(real_redis_client, root):
-    return await real_redis_client.fcall(
-        type(root).Meta.cascade_function_name,
-        1,
-        root.key,
-        type(root).__name__,
-        SPECIAL_FIELD_KEY_PREFIX,
-        type(root).Meta.ttl,
-        1,
-    )
 
 
 # --- Test A (CASF-04): RedisSet[ForeignKey] reach ---
@@ -46,12 +35,11 @@ async def test_set_ref_parent_reaches_and_refreshes_both_set_members(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, parent)
+    await apply_cascade(real_redis_client, parent)
 
-    # Assert
-    assert await real_redis_client.ttl(parent.key) > 0
-    assert await real_redis_client.ttl(author1.key) > 0
-    assert await real_redis_client.ttl(author2.key) > 0
+    # Assert (root and both SET-referenced members refresh to their own Meta.ttl)
+    for key in (parent.key, author1.key, author2.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test B (CASF-05): RedisPriorityQueue[ForeignKey] reach ---
@@ -67,11 +55,11 @@ async def test_pq_ref_parent_reaches_and_refreshes_pq_member(real_redis_client):
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, parent)
+    await apply_cascade(real_redis_client, parent)
 
-    # Assert
-    assert await real_redis_client.ttl(parent.key) > 0
-    assert await real_redis_client.ttl(author.key) > 0
+    # Assert (root and the PQ-referenced member refresh to their own Meta.ttl)
+    for key in (parent.key, author.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test C (CASF-06 dangling reuse, D-02) ---
@@ -90,12 +78,12 @@ async def test_set_ref_dangling_member_reuses_existing_dangling_count(
         await real_redis_client.persist(key)
 
     # Act
-    result = await _apply_cascade(real_redis_client, parent)
+    result = await apply_cascade(real_redis_client, parent)
 
     # Assert (no separate SF-dangling counter -- reuses the existing dangling shape)
     assert result == [1, 0]
-    assert await real_redis_client.ttl(parent.key) > 0
-    assert await real_redis_client.ttl(author.key) > 0
+    for key in (parent.key, author.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test D (CASF-07 self-ref in SET) ---
@@ -109,10 +97,10 @@ async def test_set_ref_self_node_terminates_without_hanging(real_redis_client):
     await real_redis_client.persist(node.key)
 
     # Act (bounded by the shared visited map; must not hang or error)
-    await _apply_cascade(real_redis_client, node)
+    await apply_cascade(real_redis_client, node)
 
     # Assert
-    assert await real_redis_client.ttl(node.key) > 0
+    assert 0 < await real_redis_client.ttl(node.key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test E (CASF-07 mixed-edge max-budget-wins) ---
@@ -135,7 +123,7 @@ async def test_mixed_edge_shared_child_walked_at_the_larger_sf_budget(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert (deep_set depth=4 SF budget wins over shallow_inline depth=1)
     refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
@@ -157,11 +145,11 @@ async def test_malformed_and_non_string_sf_members_are_tolerated(real_redis_clie
         await real_redis_client.persist(key)
 
     # Act (must not raise despite the malformed/non-string members)
-    await _apply_cascade(real_redis_client, parent)
+    await apply_cascade(real_redis_client, parent)
 
     # Assert
-    assert await real_redis_client.ttl(parent.key) > 0
-    assert await real_redis_client.ttl(author.key) > 0
+    for key in (parent.key, author.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test G (CASF-07 self-ref in PQ/ZSET) ---
@@ -175,10 +163,10 @@ async def test_pq_ref_self_node_terminates_without_hanging(real_redis_client):
     await real_redis_client.persist(node.key)
 
     # Act (exercises the ZRANGE branch's cycle-safety, independent of Test D)
-    await _apply_cascade(real_redis_client, node)
+    await apply_cascade(real_redis_client, node)
 
     # Assert
-    assert await real_redis_client.ttl(node.key) > 0
+    assert 0 < await real_redis_client.ttl(node.key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
 # --- Test H (CASF-07 SF-only dual-edge diamond) ---
@@ -197,9 +185,9 @@ async def test_sf_only_dual_edge_diamond_shared_child_refreshed_exactly_once(
         await real_redis_client.persist(key)
 
     # Act (must not error from the double-visit -- visited-map dedup across SET+ZSET)
-    result = await _apply_cascade(real_redis_client, root)
+    result = await apply_cascade(real_redis_client, root)
 
     # Assert
-    assert await real_redis_client.ttl(root.key) > 0
-    assert await real_redis_client.ttl(child.key) > 0
+    for key in (root.key, child.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
     assert result == [0, 0]

--- a/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
@@ -152,6 +152,27 @@ async def test_malformed_and_non_string_sf_members_are_tolerated(real_redis_clie
         assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
 
+@pytest.mark.asyncio
+async def test_wrongtype_sf_container_key_is_tolerated_not_an_aborted_cascade(
+    real_redis_client,
+):
+    # Arrange
+    # This is the SOLE regression guard for the SF-container counterpart of the
+    # inline WRONGTYPE-degradation fix (test_cascade_apply_skips_corrupt_
+    # wrongtype_reached_target_sanity in test_cascade_ttl_apply.py): the sf_key
+    # is a STRING, not a SET, so SMEMBERS raises WRONGTYPE inside push_sf_edge.
+    parent = await CascadeSetRefParent().asave()
+    sf_key = RedisSet.special_field_key(parent.key, "refs")
+    await real_redis_client.set(sf_key, "not-a-set")
+    await real_redis_client.persist(parent.key)
+
+    # Act (must not raise/abort the whole FCALL despite the WRONGTYPE key)
+    await apply_cascade(real_redis_client, parent)
+
+    # Assert (root still refreshes even though the SF edge was a dead end)
+    assert 0 < await real_redis_client.ttl(parent.key) <= CASCADE_FIXTURE_TTL_SECONDS
+
+
 # --- Test G (CASF-07 self-ref in PQ/ZSET) ---
 
 

--- a/tests/integration/foreign_keys/test_cascade_sf_held_ref_public_api.py
+++ b/tests/integration/foreign_keys/test_cascade_sf_held_ref_public_api.py
@@ -1,0 +1,67 @@
+import pytest
+
+from tests.models.cascade_types import (
+    CascadeAuthor,
+    CascadePQRefParent,
+    CascadeSetRefParent,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
+
+
+# --- Test A (CASF-04/05): asave() fires the cascade Function for an SF-only parent ---
+
+
+@pytest.mark.asyncio
+async def test_asave_refreshes_set_held_ref_child_ttl(real_redis_client):
+    # Arrange
+    parent = await CascadeSetRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.refs.aadd(author.key)
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act (public API only, no internal cascade-invocation helper)
+    await parent.asave()
+
+    # Assert
+    assert await real_redis_client.ttl(author.key) > 0
+
+
+# --- Test B (CASF-04/05): aset_ttl(cascade=True) fires the cascade Function ---
+
+
+@pytest.mark.asyncio
+async def test_aset_ttl_cascade_refreshes_set_held_ref_child_ttl(real_redis_client):
+    # Arrange
+    parent = await CascadeSetRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.refs.aadd(author.key)
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await parent.aset_ttl(parent.Meta.ttl, cascade=True)
+
+    # Assert
+    assert await real_redis_client.ttl(author.key) > 0
+    assert result.dangling_children == 0
+
+
+# --- Test C (CASF-04/05/06): PQ-held ref shape, via asave() ---
+
+
+@pytest.mark.asyncio
+async def test_asave_refreshes_pq_held_ref_child_ttl(real_redis_client):
+    # Arrange
+    parent = await CascadePQRefParent().asave()
+    author = await CascadeAuthor(name="a").asave()
+    await parent.queue.apush(author.key, priority=1.0)
+    for key in (parent.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act (public API only, no internal cascade-invocation helper)
+    await parent.asave()
+
+    # Assert
+    assert await real_redis_client.ttl(author.key) > 0

--- a/tests/integration/foreign_keys/test_cascade_ttl_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_ttl_apply.py
@@ -3,6 +3,7 @@ import pytest
 from rapyer.types.priority_queue import RedisPriorityQueue
 from rapyer.types.redis_set import RedisSet
 from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
     CASCADE_FIXTURE_TTL_SECONDS,
     CascadeAuthor,
@@ -16,18 +17,6 @@ from tests.models.cascade_types import (
 ROOT_TTL_SECONDS = 120
 
 pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
-
-
-async def _apply_cascade(real_redis_client, root):
-    return await real_redis_client.fcall(
-        type(root).Meta.cascade_function_name,
-        1,
-        root.key,
-        type(root).__name__,
-        SPECIAL_FIELD_KEY_PREFIX,
-        type(root).Meta.ttl,
-        1,
-    )
 
 
 # --- Confirmatory dual-backend parity ---
@@ -49,7 +38,7 @@ async def test_cascade_apply_refreshes_special_field_child_keys_sanity(
     await real_redis_client.persist(child.key)
 
     # Act
-    await _apply_cascade(real_redis_client, parent)
+    await apply_cascade(real_redis_client, parent)
 
     # Assert
     assert await real_redis_client.ttl(parent.key) > 0
@@ -84,7 +73,7 @@ async def test_cascade_apply_refreshes_every_collection_of_fk_element_sanity(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, book)
+    await apply_cascade(real_redis_client, book)
 
     # Assert
     assert await real_redis_client.ttl(book.key) > 0
@@ -109,7 +98,7 @@ async def test_cascade_apply_refreshes_every_dict_value_fk_element_sanity(
         await real_redis_client.persist(key)
 
     # Act
-    await _apply_cascade(real_redis_client, book)
+    await apply_cascade(real_redis_client, book)
 
     # Assert
     assert await real_redis_client.ttl(book.key) > 0
@@ -131,7 +120,7 @@ async def test_cascade_apply_skips_corrupt_wrongtype_reached_target_sanity(
     await real_redis_client.persist("CascadeChainNode:corrupt")
 
     # Act - before the Lua fix this raises (RED); after the fix it must not (GREEN)
-    await _apply_cascade(real_redis_client, root)
+    await apply_cascade(real_redis_client, root)
 
     # Assert
     assert await real_redis_client.ttl(root.key) > 0

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -313,6 +313,85 @@ class CascadeMaxBudgetRoot(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
 
 
+# --- SF-held-ref fixtures (FK elements held inside RedisSet / RedisPriorityQueue) ---
+
+
+class CascadeSetRefParent(AtomicRedisModel):
+    """SF-held-ref shape: FK references held inside a RedisSet, per-field enabled."""
+
+    name: str = "set_ref"
+    refs: Annotated[RedisSet[Reference[CascadeAuthor]], CascadeTTL()] = Field(
+        default_factory=RedisSet
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePQRefParent(AtomicRedisModel):
+    """SF-held-ref shape: FK references held inside a RedisPriorityQueue."""
+
+    name: str = "pq_ref"
+    queue: Annotated[
+        RedisPriorityQueue[Reference[CascadeAuthor]], CascadeTTL(depth=2)
+    ] = Field(default_factory=RedisPriorityQueue)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeSetRefBlanket(AtomicRedisModel):
+    """SF-held-ref field with no per-field marker; cascades via the blanket global."""
+
+    name: str = "set_ref_blanket"
+    refs: RedisSet[Reference[CascadeAuthor]] = Field(default_factory=RedisSet)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        cascade_ttl=CascadeTTL(depth=2), ttl=CASCADE_FIXTURE_TTL_SECONDS
+    )
+
+
+class CascadeSetRefOptOut(AtomicRedisModel):
+    """SF-held-ref field opts OUT of an otherwise-blanket-enabled global."""
+
+    name: str = "set_ref_opt_out"
+    refs: Annotated[RedisSet[Reference[CascadeAuthor]], CascadeTTL(enabled=False)] = (
+        Field(default_factory=RedisSet)
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        cascade_ttl=CascadeTTL(), ttl=CASCADE_FIXTURE_TTL_SECONDS
+    )
+
+
+class CascadeSetRefNoTtlTarget(AtomicRedisModel):
+    """SF-held-ref target with no Meta.ttl — fail-fast fixture, not registered."""
+
+    name: str = "no_ttl_target"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig()
+
+
+class CascadeSetRefToNoTtl(AtomicRedisModel):
+    """Root has a ttl; its SF-held-ref target does not — target violation."""
+
+    name: str = "set_ref_to_no_ttl"
+    refs: Annotated[RedisSet[Reference[CascadeSetRefNoTtlTarget]], CascadeTTL()] = (
+        Field(default_factory=RedisSet)
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeSetRefRootNoTtl(AtomicRedisModel):
+    """Root-with-only-SF-edges has no Meta.ttl — root violation."""
+
+    name: str = "set_ref_root_no_ttl"
+    refs: Annotated[RedisSet[Reference[CascadeAuthor]], CascadeTTL()] = Field(
+        default_factory=RedisSet
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig()
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,
@@ -342,4 +421,8 @@ ALL_CASCADE_MODELS = [
     CascadeWR02SharedChild,
     CascadeWR02Root,
     CascadeMaxBudgetRoot,
+    CascadeSetRefParent,
+    CascadePQRefParent,
+    CascadeSetRefBlanket,
+    CascadeSetRefOptOut,
 ]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -395,6 +395,94 @@ class CascadeSetRefRootNoTtl(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(init_with_rapyer=False)
 
 
+# --- SF-held-ref hard-shape fixtures (Phase 2: server-side traversal proof) ---
+
+
+class CascadeSetRefSelfNode(AtomicRedisModel):
+    """Self-reference held inside a RedisSet: the node's own key can be a
+    member of its own ``peers`` field. Proves the shared visited map
+    terminates this cycle via the SMEMBERS read branch instead of hanging."""
+
+    name: str = "set_ref_self"
+    peers: Annotated[RedisSet[Reference["CascadeSetRefSelfNode"]], CascadeTTL()] = (
+        Field(default_factory=RedisSet)
+    )
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePQRefSelfNode(AtomicRedisModel):
+    """Same self-reference shape as CascadeSetRefSelfNode but held inside a
+    RedisPriorityQueue instead of a RedisSet — proves the cycle-safety
+    guarantee holds independently for the ZRANGE read branch."""
+
+    name: str = "pq_ref_self"
+    peers: Annotated[
+        RedisPriorityQueue[Reference["CascadePQRefSelfNode"]], CascadeTTL()
+    ] = Field(default_factory=RedisPriorityQueue)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeMixedEdgeSharedChild(AtomicRedisModel):
+    """Chain node reached by CascadeMixedEdgeSharedChildRoot via both an
+    inline edge and an SF-held-ref edge. Blanket (non-override) cascade so
+    depth genuinely decrements on every established hop."""
+
+    name: str = "mixed_edge_shared_child"
+    onward: Optional[Reference["CascadeMixedEdgeSharedChild"]] = None
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        cascade_ttl=CascadeTTL(), ttl=CASCADE_FIXTURE_TTL_SECONDS
+    )
+
+
+class CascadeMixedEdgeSharedChildRoot(AtomicRedisModel):
+    """Two fields point at the SAME saved CascadeMixedEdgeSharedChild
+    instance: ``shallow_inline`` (inline FK, override, depth=1) and
+    ``deep_set`` (SF-held-ref, override, depth=4). Proves SF edges
+    participate in the SAME best-budget-per-node visited map as inline
+    edges — the shared child is walked at the larger SF budget regardless
+    of which edge's push_child call happens first."""
+
+    name: str = "mixed_edge_shared_child_root"
+    shallow_inline: Annotated[
+        Reference[CascadeMixedEdgeSharedChild], CascadeTTL(depth=1)
+    ]
+    deep_set: Annotated[
+        RedisSet[Reference[CascadeMixedEdgeSharedChild]], CascadeTTL(depth=4)
+    ] = Field(default_factory=RedisSet)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeSfDiamondChild(AtomicRedisModel):
+    """Plain leaf reached by CascadeSfDiamondRoot via two different
+    SF-container kinds on the same root (SET and ZSET)."""
+
+    name: str = "sf_diamond_child"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeSfDiamondRoot(AtomicRedisModel):
+    """Two independent SF-held-ref fields (one RedisSet, one
+    RedisPriorityQueue) both pointing at the SAME saved
+    CascadeSfDiamondChild instance. Proves a child reached via two
+    different SF-container kinds converges through the shared visited map
+    and is re-armed exactly once, with no double-processing error."""
+
+    name: str = "sf_diamond_root"
+    left: Annotated[RedisSet[Reference[CascadeSfDiamondChild]], CascadeTTL()] = Field(
+        default_factory=RedisSet
+    )
+    right: Annotated[
+        RedisPriorityQueue[Reference[CascadeSfDiamondChild]], CascadeTTL()
+    ] = Field(default_factory=RedisPriorityQueue)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,
@@ -428,4 +516,10 @@ ALL_CASCADE_MODELS = [
     CascadePQRefParent,
     CascadeSetRefBlanket,
     CascadeSetRefOptOut,
+    CascadeSetRefSelfNode,
+    CascadePQRefSelfNode,
+    CascadeMixedEdgeSharedChild,
+    CascadeMixedEdgeSharedChildRoot,
+    CascadeSfDiamondChild,
+    CascadeSfDiamondRoot,
 ]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -367,7 +367,8 @@ class CascadeSetRefNoTtlTarget(AtomicRedisModel):
 
     name: str = "no_ttl_target"
 
-    Meta: ClassVar[RedisConfig] = RedisConfig()
+    # Excluded from REDIS_MODELS so it never trips init_rapyer()'s full-set validation.
+    Meta: ClassVar[RedisConfig] = RedisConfig(init_with_rapyer=False)
 
 
 class CascadeSetRefToNoTtl(AtomicRedisModel):
@@ -378,7 +379,9 @@ class CascadeSetRefToNoTtl(AtomicRedisModel):
         Field(default_factory=RedisSet)
     )
 
-    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+    Meta: ClassVar[RedisConfig] = RedisConfig(
+        ttl=CASCADE_FIXTURE_TTL_SECONDS, init_with_rapyer=False
+    )
 
 
 class CascadeSetRefRootNoTtl(AtomicRedisModel):
@@ -389,7 +392,7 @@ class CascadeSetRefRootNoTtl(AtomicRedisModel):
         default_factory=RedisSet
     )
 
-    Meta: ClassVar[RedisConfig] = RedisConfig()
+    Meta: ClassVar[RedisConfig] = RedisConfig(init_with_rapyer=False)
 
 
 # Full cascade-model set shared by unit and integration cascade fixtures.

--- a/tests/unit/cascade/conftest.py
+++ b/tests/unit/cascade/conftest.py
@@ -24,7 +24,11 @@ from tests.models.cascade_types import (
     CascadeMaxBudgetRoot,
     CascadeMultiDepthRoot,
     CascadeNestedDepthRoot,
+    CascadePQRefParent,
     CascadeProfile,
+    CascadeSetRefBlanket,
+    CascadeSetRefOptOut,
+    CascadeSetRefParent,
     CascadeShallowRoot,
     CascadeSpecialChild,
     CascadeSpecialParent,
@@ -61,6 +65,10 @@ CASCADE_PLANNER_MODELS = [
     CascadeWR02SharedChild,
     CascadeWR02Root,
     CascadeMaxBudgetRoot,
+    CascadeSetRefParent,
+    CascadePQRefParent,
+    CascadeSetRefBlanket,
+    CascadeSetRefOptOut,
 ]
 
 # init_rapyer() authoritatively resets Meta.cascade_ttl to None on every registered

--- a/tests/unit/cascade/conftest.py
+++ b/tests/unit/cascade/conftest.py
@@ -1,3 +1,6 @@
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, patch
+
 import pytest
 import pytest_asyncio
 
@@ -101,6 +104,25 @@ def setup_fake_redis_for_cascade_models(fake_redis_client):
         model.Meta.redis = original_redis
         model.Meta.is_fake_redis = original_is_fake
         model.Meta.cascade_ttl = original_cascade_ttl
+
+
+@pytest.fixture
+def fcall_pipeline_spy():
+    """Patches ensure_pipeline + scripts_registry.run_fcall so a refresh_ttl()/
+    aset_ttl() call can be asserted against the FCALL args without touching real
+    Redis. Accepts the optional should_execute kwarg aset_ttl's call site passes.
+    Yields (mock_pipe, mock_run_fcall)."""
+    mock_pipe = MagicMock()
+
+    @asynccontextmanager
+    async def fake_ensure_pipeline(_meta, should_execute=True):
+        yield mock_pipe
+
+    with (
+        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
+        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
+    ):
+        yield mock_pipe, mock_run_fcall
 
 
 @pytest_asyncio.fixture

--- a/tests/unit/cascade/test_aset_ttl_cascade_flag.py
+++ b/tests/unit/cascade/test_aset_ttl_cascade_flag.py
@@ -1,6 +1,5 @@
 import inspect
-from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,24 +21,18 @@ def test_aset_ttl_signature_has_cascade_kwarg_defaulting_false():
 
 
 @pytest.mark.asyncio
-async def test_aset_ttl_default_cascade_false_runs_the_script_with_cascade_argv_zero():
+async def test_aset_ttl_default_cascade_false_runs_the_script_with_cascade_argv_zero(
+    fcall_pipeline_spy,
+):
     # Arrange
     # aset_ttl is unified onto the cascade script for EVERY call, including
     # the default cascade=False -- only the trailing ARGV cascade flag
     # differs, never a separate per-key EXPIRE branch.
-    root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     mock_pipe.execute = AsyncMock(return_value=[[0, 0]])
+    root = CascadeChainRoot(head="CascadeChainNode:fake")
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta, should_execute=True):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base._context_pipe") as mock_context_pipe,
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
+    with patch("rapyer.base._context_pipe") as mock_context_pipe:
         mock_context_pipe.get.return_value = None
         # Act
         result = await root.aset_ttl(TTL_SECONDS)
@@ -61,21 +54,15 @@ async def test_aset_ttl_default_cascade_false_runs_the_script_with_cascade_argv_
 
 
 @pytest.mark.asyncio
-async def test_aset_ttl_cascade_true_runs_the_script_with_cascade_argv_one():
+async def test_aset_ttl_cascade_true_runs_the_script_with_cascade_argv_one(
+    fcall_pipeline_spy,
+):
     # Arrange
-    root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     mock_pipe.execute = AsyncMock(return_value=[[0, 0]])
+    root = CascadeChainRoot(head="CascadeChainNode:fake")
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta, should_execute=True):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base._context_pipe") as mock_context_pipe,
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
+    with patch("rapyer.base._context_pipe") as mock_context_pipe:
         mock_context_pipe.get.return_value = None
         # Act
         result = await root.aset_ttl(TTL_SECONDS, cascade=True)
@@ -95,23 +82,17 @@ async def test_aset_ttl_cascade_true_runs_the_script_with_cascade_argv_one():
 
 
 @pytest.mark.asyncio
-async def test_aset_ttl_cascade_standalone_owns_execution_and_returns_cascade_result():
+async def test_aset_ttl_cascade_standalone_owns_execution_and_returns_cascade_result(
+    fcall_pipeline_spy,
+):
     # Arrange
     # Standalone call (no outer pipeline): enqueues run_sha, awaits
     # pipe.execute() itself, and decodes the two-element result.
-    root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     mock_pipe.execute = AsyncMock(return_value=[[1, 2]])
+    root = CascadeChainRoot(head="CascadeChainNode:fake")
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta, should_execute=True):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base._context_pipe") as mock_context_pipe,
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
+    with patch("rapyer.base._context_pipe") as mock_context_pipe:
         mock_context_pipe.get.return_value = None
         # Act
         result = await root.aset_ttl(TTL_SECONDS, cascade=True)
@@ -132,25 +113,19 @@ async def test_aset_ttl_cascade_standalone_owns_execution_and_returns_cascade_re
 
 
 @pytest.mark.asyncio
-async def test_aset_ttl_cascade_standalone_awaits_pipe_execute_directly():
+async def test_aset_ttl_cascade_standalone_awaits_pipe_execute_directly(
+    fcall_pipeline_spy,
+):
     # Arrange
     # The standalone (should_execute=False, own-pipeline) branch executes with
     # a bare `await pipe.execute()` -- this path does not yet self-heal a
     # NOSCRIPT (tracked as a follow-up, see NOSCRIPT-ISSUE.md). It must still
     # capture the awaited results[-1] for the CascadeResult.
-    root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
+    mock_pipe, _ = fcall_pipeline_spy
     mock_pipe.execute = AsyncMock(return_value=[[3, 4]])
+    root = CascadeChainRoot(head="CascadeChainNode:fake")
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta, should_execute=True):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base._context_pipe") as mock_context_pipe,
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall"),
-    ):
+    with patch("rapyer.base._context_pipe") as mock_context_pipe:
         mock_context_pipe.get.return_value = None
         # Act
         result = await root.aset_ttl(TTL_SECONDS, cascade=True)
@@ -161,23 +136,17 @@ async def test_aset_ttl_cascade_standalone_awaits_pipe_execute_directly():
 
 
 @pytest.mark.asyncio
-async def test_aset_ttl_cascade_inside_outer_pipeline_returns_none_without_executing():
+async def test_aset_ttl_cascade_inside_outer_pipeline_returns_none_without_executing(
+    fcall_pipeline_spy,
+):
     # Arrange
     # Called while already inside an outer pipeline: enqueues into the
     # outer pipe, never calls pipe.execute() itself, returns None.
-    root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     mock_pipe.execute = AsyncMock()
+    root = CascadeChainRoot(head="CascadeChainNode:fake")
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta, should_execute=True):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base._context_pipe") as mock_context_pipe,
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
+    with patch("rapyer.base._context_pipe") as mock_context_pipe:
         mock_context_pipe.get.return_value = mock_pipe
         # Act
         result = await root.aset_ttl(TTL_SECONDS, cascade=True)

--- a/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
@@ -1,0 +1,36 @@
+import pytest
+
+from rapyer.result import CascadeResult
+from rapyer.types.foreign_key import ForeignKey
+from rapyer.types.redis_set import RedisSet
+from tests.models.cascade_types import (
+    CascadeAuthor,
+    CascadeSetRefParent,
+)
+
+TTL_SECONDS = 120
+
+
+@pytest.mark.asyncio
+async def test_set_ref_parent_cascade_on_fakeredis_refreshes_root_and_container_not_member(
+    setup_fake_redis_for_cascade_apply,
+    fake_redis_client,
+):
+    # Arrange: fakeredis fast path refreshes only own keys, never SET members.
+    author = await CascadeAuthor(name="author").asave()
+    parent = await CascadeSetRefParent().asave()
+    await parent.refs.aadd(ForeignKey(author.key))
+
+    refs_key = RedisSet.special_field_key(parent.key, "refs")
+    await fake_redis_client.persist(parent.key)
+    await fake_redis_client.persist(refs_key)
+    await fake_redis_client.persist(author.key)
+
+    # Act
+    result = await parent.aset_ttl(TTL_SECONDS, cascade=True)
+
+    # Assert
+    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert await fake_redis_client.ttl(parent.key) > 0
+    assert await fake_redis_client.ttl(refs_key) > 0
+    assert await fake_redis_client.ttl(author.key) in (-1, -2)

--- a/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
@@ -2,9 +2,11 @@ import pytest
 
 from rapyer.result import CascadeResult
 from rapyer.types.foreign_key import ForeignKey
+from rapyer.types.priority_queue import RedisPriorityQueue
 from rapyer.types.redis_set import RedisSet
 from tests.models.cascade_types import (
     CascadeAuthor,
+    CascadePQRefParent,
     CascadeSetRefParent,
 )
 
@@ -33,4 +35,29 @@ async def test_set_ref_parent_cascade_on_fakeredis_refreshes_root_and_container_
     assert result == CascadeResult(dangling_children=0, dangling_special=0)
     assert await fake_redis_client.ttl(parent.key) > 0
     assert await fake_redis_client.ttl(refs_key) > 0
+    assert await fake_redis_client.ttl(author.key) in (-1, -2)
+
+
+@pytest.mark.asyncio
+async def test_pq_ref_parent_cascade_on_fakeredis_refreshes_root_and_container_not_member(
+    setup_fake_redis_for_cascade_apply,
+    fake_redis_client,
+):
+    # Arrange: same shape as the SET proof above, for the ZSET-backed PQ container.
+    author = await CascadeAuthor(name="author").asave()
+    parent = await CascadePQRefParent().asave()
+    await parent.queue.apush(ForeignKey(author.key), priority=1.0)
+
+    queue_key = RedisPriorityQueue.special_field_key(parent.key, "queue")
+    await fake_redis_client.persist(parent.key)
+    await fake_redis_client.persist(queue_key)
+    await fake_redis_client.persist(author.key)
+
+    # Act
+    result = await parent.aset_ttl(TTL_SECONDS, cascade=True)
+
+    # Assert
+    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert await fake_redis_client.ttl(parent.key) > 0
+    assert await fake_redis_client.ttl(queue_key) > 0
     assert await fake_redis_client.ttl(author.key) in (-1, -2)

--- a/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
@@ -3,13 +3,12 @@ import json
 import pytest
 
 from rapyer.cascade.planner import (
+    _static_walk_fk_edges,
     build_cascade_plan,
     cascade_plan_json,
     validate_cascade_ttl_targets,
 )
 from rapyer.errors import CascadeTargetTtlMissingError
-from rapyer.types.priority_queue import RedisPriorityQueue
-from rapyer.types.redis_set import RedisSet
 from tests.models.cascade_types import (
     CascadeAuthor,
     CascadeBlanketRoot,
@@ -22,6 +21,7 @@ from tests.models.cascade_types import (
     CascadeSetRefParent,
     CascadeSetRefRootNoTtl,
     CascadeSetRefToNoTtl,
+    CascadeSpecialChild,
 )
 
 pytestmark = pytest.mark.usefixtures("setup_fake_redis_for_cascade_models")
@@ -144,9 +144,26 @@ def test_positive_control_all_ttl_present_does_not_raise():
     validate_cascade_ttl_targets(plan)
 
 
-def test_guard_redis_set_contains_fk_field_is_false_and_field_not_in_contain_fk():
-    # Guards D-02: the SF edge comes from _special_field_names, not _contain_fk.
-    assert RedisSet.contains_fk_field() is False
-    assert RedisPriorityQueue.contains_fk_field() is False
-    assert "refs" not in CascadeSetRefParent._contain_fk
+def test_sf_of_fk_field_lands_in_both_contain_fk_and_special_field_names():
+    """Unified detection (reverses D-02): an SF-of-FK field is both a traversal edge
+    source (_contain_fk) and a refresh-suffix source (_special_field_names)."""
+    assert CascadeSetRefParent.contains_fk_field() is True
+    assert CascadePQRefParent.contains_fk_field() is True
+    assert "refs" in CascadeSetRefParent._contain_fk
     assert "refs" in CascadeSetRefParent._special_field_names
+    assert "queue" in CascadePQRefParent._contain_fk
+    assert "queue" in CascadePQRefParent._special_field_names
+
+
+def test_plain_sf_container_without_fk_stays_off_the_cascade_path():
+    # A non-FK SF container must not enter _contain_fk nor trip the trigger gate.
+    assert "tags" not in CascadeSpecialChild._contain_fk
+    assert "scores" not in CascadeSpecialChild._contain_fk
+    assert CascadeSpecialChild._contains_foreign_key() is False
+
+
+def test_nested_sf_held_ref_traversal_stays_deferred():
+    # Nested SF-held refs are deferred: the SF branch fires only at top level.
+    fks = []
+    _static_walk_fk_edges(CascadeSetRefParent, "$.holder", fks, top_level=False)
+    assert all(edge.sf_container is None for edge in fks)

--- a/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
@@ -1,0 +1,152 @@
+import json
+
+import pytest
+
+from rapyer.cascade.planner import (
+    build_cascade_plan,
+    cascade_plan_json,
+    validate_cascade_ttl_targets,
+)
+from rapyer.errors import CascadeTargetTtlMissingError
+from rapyer.types.priority_queue import RedisPriorityQueue
+from rapyer.types.redis_set import RedisSet
+from tests.models.cascade_types import (
+    CascadeAuthor,
+    CascadeBlanketRoot,
+    CascadeBookCollection,
+    CascadeBookDirect,
+    CascadePQRefParent,
+    CascadeSetRefBlanket,
+    CascadeSetRefNoTtlTarget,
+    CascadeSetRefOptOut,
+    CascadeSetRefParent,
+    CascadeSetRefRootNoTtl,
+    CascadeSetRefToNoTtl,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_fake_redis_for_cascade_models")
+
+
+def test_set_held_ref_produces_one_edge_marked_set():
+    # Act
+    plan = build_cascade_plan([CascadeSetRefParent, CascadeAuthor])
+
+    # Assert
+    edges = plan["CascadeSetRefParent"].fks
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.sf_container == "set"
+    assert edge.path == "refs"
+    assert edge.target == "CascadeAuthor"
+    assert edge.is_collection is True
+    assert edge.depth is None
+
+
+def test_pq_held_ref_produces_one_edge_marked_zset_with_depth():
+    # Act
+    plan = build_cascade_plan([CascadePQRefParent, CascadeAuthor])
+
+    # Assert
+    edges = plan["CascadePQRefParent"].fks
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.sf_container == "zset"
+    assert edge.path == "queue"
+    assert edge.target == "CascadeAuthor"
+    assert edge.is_collection is True
+    assert edge.depth == 2
+
+
+def test_sf_edge_coexists_with_the_refresh_only_special_suffix():
+    # Act
+    plan = build_cascade_plan([CascadeSetRefParent, CascadeAuthor])
+
+    # Assert
+    entry = plan["CascadeSetRefParent"]
+    assert entry.special_suffixes == ["refs"]
+    assert len(entry.fks) == 1
+    assert entry.fks[0].sf_container == "set"
+
+
+def test_blanket_global_enables_sf_edge_with_global_depth():
+    # Act
+    plan = build_cascade_plan([CascadeSetRefBlanket, CascadeAuthor])
+
+    # Assert
+    edges = plan["CascadeSetRefBlanket"].fks
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.sf_container == "set"
+    assert edge.depth == 2
+    assert edge.resets_depth_budget is False
+
+
+def test_field_opt_out_beats_enabled_global_and_emits_no_sf_edge():
+    # Act
+    plan = build_cascade_plan([CascadeSetRefOptOut, CascadeAuthor])
+
+    # Assert
+    assert plan["CascadeSetRefOptOut"].fks == []
+
+
+def test_non_sf_edge_json_has_no_sf_container_key():
+    # Act
+    plan = build_cascade_plan([CascadeBookCollection, CascadeAuthor])
+    payload = json.loads(cascade_plan_json(plan))
+
+    # Assert
+    edge_dict = payload["CascadeBookCollection"]["fks"][0]
+    assert "sf_container" not in edge_dict
+
+
+def test_inline_edge_has_none_sf_container_on_the_dataclass():
+    # Act
+    plan = build_cascade_plan([CascadeBlanketRoot, CascadeBookDirect, CascadeAuthor])
+
+    # Assert
+    for entry in plan.values():
+        for edge in entry.fks:
+            assert edge.sf_container is None
+
+
+# --- Task 3: fail-fast validation regression tests for SF-held-ref targets ---
+
+
+def test_sf_held_ref_target_with_no_ttl_fails_fast():
+    # Arrange
+    plan = build_cascade_plan([CascadeSetRefToNoTtl, CascadeSetRefNoTtlTarget])
+
+    # Act
+    with pytest.raises(CascadeTargetTtlMissingError) as exc_info:
+        validate_cascade_ttl_targets(plan)
+
+    # Assert
+    assert exc_info.value.model_name == "CascadeSetRefNoTtlTarget"
+
+
+def test_root_with_only_sf_edges_and_no_ttl_fails_fast():
+    # Arrange
+    plan = build_cascade_plan([CascadeSetRefRootNoTtl, CascadeAuthor])
+
+    # Act
+    with pytest.raises(CascadeTargetTtlMissingError) as exc_info:
+        validate_cascade_ttl_targets(plan)
+
+    # Assert
+    assert exc_info.value.model_name == "CascadeSetRefRootNoTtl"
+
+
+def test_positive_control_all_ttl_present_does_not_raise():
+    # Arrange
+    plan = build_cascade_plan([CascadeSetRefParent, CascadeAuthor])
+
+    # Act
+    validate_cascade_ttl_targets(plan)
+
+
+def test_guard_redis_set_contains_fk_field_is_false_and_field_not_in_contain_fk():
+    # Guards D-02: the SF edge comes from _special_field_names, not _contain_fk.
+    assert RedisSet.contains_fk_field() is False
+    assert RedisPriorityQueue.contains_fk_field() is False
+    assert "refs" not in CascadeSetRefParent._contain_fk
+    assert "refs" in CascadeSetRefParent._special_field_names

--- a/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
@@ -155,11 +155,11 @@ def test_sf_of_fk_field_lands_in_both_contain_fk_and_special_field_names():
     assert "queue" in CascadePQRefParent._special_field_names
 
 
-def test_plain_sf_container_without_fk_stays_off_the_cascade_path():
-    # A non-FK SF container must not enter _contain_fk nor trip the trigger gate.
+def test_plain_sf_container_is_not_an_fk_edge_but_needs_the_cascade_script():
+    # Not an FK edge, but its special key still routes through the cascade script.
     assert "tags" not in CascadeSpecialChild._contain_fk
     assert "scores" not in CascadeSpecialChild._contain_fk
-    assert CascadeSpecialChild._contains_foreign_key() is False
+    assert CascadeSpecialChild._needs_cascade_script() is True
 
 
 def test_nested_sf_held_ref_traversal_stays_deferred():

--- a/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
+++ b/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
@@ -1,0 +1,97 @@
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
+from tests.models.cascade_types import (
+    CascadePQRefParent,
+    CascadeSetRefOptOut,
+    CascadeSetRefParent,
+)
+
+
+@pytest.mark.asyncio
+async def test_set_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
+    # Arrange: SF-only parent, sole cascade edge is its per-field-enabled `refs` set.
+    parent = CascadeSetRefParent()
+    mock_pipe = MagicMock()
+
+    @asynccontextmanager
+    async def fake_ensure_pipeline(_meta):
+        yield mock_pipe
+
+    with (
+        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
+        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
+    ):
+        # Act
+        await parent.refresh_ttl(can_use_pipeline=True)
+
+    # Assert
+    mock_run_fcall.assert_called_once_with(
+        mock_pipe,
+        type(parent).Meta.cascade_function_name,
+        1,
+        parent.key,
+        "CascadeSetRefParent",
+        SPECIAL_FIELD_KEY_PREFIX,
+        parent.Meta.ttl,
+        1,
+    )
+    mock_pipe.expire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
+    # Arrange: same shape, RedisPriorityQueue instead of RedisSet.
+    parent = CascadePQRefParent()
+    mock_pipe = MagicMock()
+
+    @asynccontextmanager
+    async def fake_ensure_pipeline(_meta):
+        yield mock_pipe
+
+    with (
+        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
+        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
+    ):
+        # Act
+        await parent.refresh_ttl(can_use_pipeline=True)
+
+    # Assert
+    mock_run_fcall.assert_called_once_with(
+        mock_pipe,
+        type(parent).Meta.cascade_function_name,
+        1,
+        parent.key,
+        "CascadePQRefParent",
+        SPECIAL_FIELD_KEY_PREFIX,
+        parent.Meta.ttl,
+        1,
+    )
+    mock_pipe.expire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_ref_opt_out_refresh_ttl_still_uses_plain_expire():
+    # Arrange: sole SF field opts OUT via a per-field CascadeTTL(enabled=False).
+    parent = CascadeSetRefOptOut()
+    mock_pipe = MagicMock()
+
+    @asynccontextmanager
+    async def fake_ensure_pipeline(_meta):
+        yield mock_pipe
+
+    with (
+        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
+        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
+    ):
+        # Act
+        await parent.refresh_ttl(can_use_pipeline=True)
+
+    # Assert (all_keys includes the opted-out `refs` SF key, not just the main key)
+    mock_run_fcall.assert_not_called()
+    expected_calls = [((key, parent.Meta.ttl),) for key in parent.all_keys]
+    actual_calls = [call.args for call in mock_pipe.expire.call_args_list]
+    assert actual_calls == [args for (args,) in expected_calls]

--- a/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
+++ b/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
@@ -1,6 +1,3 @@
-from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
@@ -12,21 +9,15 @@ from tests.models.cascade_types import (
 
 
 @pytest.mark.asyncio
-async def test_set_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
+async def test_set_ref_parent_refresh_ttl_calls_run_fcall_not_expire(
+    fcall_pipeline_spy,
+):
     # Arrange: SF-only parent, sole cascade edge is its per-field-enabled `refs` set.
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     parent = CascadeSetRefParent()
-    mock_pipe = MagicMock()
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
-        # Act
-        await parent.refresh_ttl(can_use_pipeline=True)
+    # Act
+    await parent.refresh_ttl(can_use_pipeline=True)
 
     # Assert
     mock_run_fcall.assert_called_once_with(
@@ -43,21 +34,15 @@ async def test_set_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
 
 
 @pytest.mark.asyncio
-async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
+async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire(
+    fcall_pipeline_spy,
+):
     # Arrange: same shape, RedisPriorityQueue instead of RedisSet.
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     parent = CascadePQRefParent()
-    mock_pipe = MagicMock()
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
-        # Act
-        await parent.refresh_ttl(can_use_pipeline=True)
+    # Act
+    await parent.refresh_ttl(can_use_pipeline=True)
 
     # Assert
     mock_run_fcall.assert_called_once_with(
@@ -74,23 +59,17 @@ async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
 
 
 @pytest.mark.asyncio
-async def test_set_ref_opt_out_refresh_ttl_gates_like_a_normal_opt_out_fk():
+async def test_set_ref_opt_out_refresh_ttl_gates_like_a_normal_opt_out_fk(
+    fcall_pipeline_spy,
+):
     """A cascade-opt-out SF field gates like any opt-out FK: _needs_cascade_script is
     True, so refresh_ttl takes the FCALL path. The plan carries no enabled edge, so the
     FCALL refreshes only the parent's own keys and follows no reference (no child)."""
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     parent = CascadeSetRefOptOut()
-    mock_pipe = MagicMock()
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
-        # Act
-        await parent.refresh_ttl(can_use_pipeline=True)
+    # Act
+    await parent.refresh_ttl(can_use_pipeline=True)
 
     # Assert
     mock_run_fcall.assert_called_once_with(

--- a/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
+++ b/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
@@ -74,8 +74,10 @@ async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
 
 
 @pytest.mark.asyncio
-async def test_set_ref_opt_out_refresh_ttl_still_uses_plain_expire():
-    # Arrange: sole SF field opts OUT via a per-field CascadeTTL(enabled=False).
+async def test_set_ref_opt_out_refresh_ttl_gates_like_a_normal_opt_out_fk():
+    """A cascade-opt-out SF field gates like any opt-out FK: _contains_foreign_key is
+    True, so refresh_ttl takes the FCALL path. The plan carries no enabled edge, so the
+    FCALL refreshes only the parent's own keys and follows no reference (no child)."""
     parent = CascadeSetRefOptOut()
     mock_pipe = MagicMock()
 
@@ -90,8 +92,15 @@ async def test_set_ref_opt_out_refresh_ttl_still_uses_plain_expire():
         # Act
         await parent.refresh_ttl(can_use_pipeline=True)
 
-    # Assert (all_keys includes the opted-out `refs` SF key, not just the main key)
-    mock_run_fcall.assert_not_called()
-    expected_calls = [((key, parent.Meta.ttl),) for key in parent.all_keys]
-    actual_calls = [call.args for call in mock_pipe.expire.call_args_list]
-    assert actual_calls == [args for (args,) in expected_calls]
+    # Assert
+    mock_run_fcall.assert_called_once_with(
+        mock_pipe,
+        type(parent).Meta.cascade_function_name,
+        1,
+        parent.key,
+        "CascadeSetRefOptOut",
+        SPECIAL_FIELD_KEY_PREFIX,
+        parent.Meta.ttl,
+        1,
+    )
+    mock_pipe.expire.assert_not_called()

--- a/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
+++ b/tests/unit/cascade/test_cascade_sf_only_trigger_gate.py
@@ -75,7 +75,7 @@ async def test_pq_ref_parent_refresh_ttl_calls_run_fcall_not_expire():
 
 @pytest.mark.asyncio
 async def test_set_ref_opt_out_refresh_ttl_gates_like_a_normal_opt_out_fk():
-    """A cascade-opt-out SF field gates like any opt-out FK: _contains_foreign_key is
+    """A cascade-opt-out SF field gates like any opt-out FK: _needs_cascade_script is
     True, so refresh_ttl takes the FCALL path. The plan carries no enabled edge, so the
     FCALL refreshes only the parent's own keys and follows no reference (no child)."""
     parent = CascadeSetRefOptOut()

--- a/tests/unit/cascade/test_refresh_ttl_cascade_branch.py
+++ b/tests/unit/cascade/test_refresh_ttl_cascade_branch.py
@@ -1,6 +1,3 @@
-from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from rapyer.types.special import SPECIAL_FIELD_KEY_PREFIX
@@ -8,21 +5,15 @@ from tests.models.cascade_types import CascadeAuthor, CascadeChainRoot
 
 
 @pytest.mark.asyncio
-async def test_refresh_ttl_cascade_enabled_model_calls_run_sha_not_expire():
+async def test_refresh_ttl_cascade_enabled_model_calls_run_sha_not_expire(
+    fcall_pipeline_spy,
+):
     # Arrange
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     root = CascadeChainRoot(head="CascadeChainNode:fake")
-    mock_pipe = MagicMock()
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
-        # Act
-        await root.refresh_ttl(can_use_pipeline=True)
+    # Act
+    await root.refresh_ttl(can_use_pipeline=True)
 
     # Assert
     mock_run_fcall.assert_called_once_with(
@@ -39,21 +30,15 @@ async def test_refresh_ttl_cascade_enabled_model_calls_run_sha_not_expire():
 
 
 @pytest.mark.asyncio
-async def test_refresh_ttl_non_cascade_model_uses_plain_expire_not_the_script():
+async def test_refresh_ttl_non_cascade_model_uses_plain_expire_not_the_script(
+    fcall_pipeline_spy,
+):
     # Arrange
+    mock_pipe, mock_run_fcall = fcall_pipeline_spy
     author = CascadeAuthor()
-    mock_pipe = MagicMock()
 
-    @asynccontextmanager
-    async def fake_ensure_pipeline(_meta):
-        yield mock_pipe
-
-    with (
-        patch("rapyer.base.ensure_pipeline", fake_ensure_pipeline),
-        patch("rapyer.base.scripts_registry.run_fcall") as mock_run_fcall,
-    ):
-        # Act
-        await author.refresh_ttl(can_use_pipeline=True)
+    # Act
+    await author.refresh_ttl(can_use_pipeline=True)
 
     # Assert
     mock_run_fcall.assert_not_called()


### PR DESCRIPTION
## Milestone v1.3.6 — Cascade Reach Through Special-Field References

Extends the v1.3.5 TTL cascade so the shared walker also discovers and re-arms `ForeignKey` references held **inside** special-field containers — `RedisSet[ForeignKey[T]]` and `RedisPriorityQueue[ForeignKey[T]]` — which live under their own SET/ZSET keys and were never read by the inline-only (`JSON.GET`) traversal. Traversal-reach only; the per-child cascading-TTL-refresh apply layer is reused unchanged.

### Phase 1 — Classify SF-held FK references into the cascade plan
- New `sf_container` discriminator on `CascadeEdge`; SF-held-ref discovery pass in `build_cascade_plan` / `_static_walk_sf_fk_edges` (precedence: field > global > off; fail-fast on a missing target `Meta.ttl`).

### Phase 2 — Traverse SF-held references server-side and re-arm children
- **`library.lua`**: new `push_sf_edge` branch reads SET (`SMEMBERS`) / ZSET (`ZRANGE`) members server-side, decodes each into its target key, and feeds them through the existing `push_child` / `next_hop` / `visited` budget machinery — so SF-reached children re-arm to their own `Meta.ttl` in the same atomic FCALL as inline-reached children.
- **Model-level trigger gate** (`rapyer/base.py`): `_contains_foreign_key()` now ORs in `_has_cascade_enabled_sf_ref_edge()` so `asave` / `aset_ttl(cascade=True)` / `refresh_ttl` actually fire the cascade Function for parents whose *only* cascade edge is SF-held (previously they silently took the native-`EXPIRE` fast path).
- **Serialization fix**: `RedisSet` / `RedisPriorityQueue._dump_members` now validate before dumping, so a raw FK key string round-trips correctly.
- **Docs**: TTL-cascade coverage matrix updated to all five cascade-eligible shapes, with a worked SF-held-ref example and the fakeredis/real-Redis divergence note.

### Verification
- Phase-goal verification: **PASSED 9/9 must-haves** (CASF-04..10 all traced).
- Cycle-safety proven: self-ref in SET/PQ, mixed inline+SF diamonds, SF-only dual-edge diamonds, and children reachable both inline and via SF all terminate and re-arm per the shared budget/visited rules.
- Dual-backend: real Redis Stack :6370 (Function path) + fakeredis root-own-`EXPIRE` fallback.
- Full suites green, zero regression: **818 unit + 1623 integration passed / 205 skipped**.

### Follow-ups (non-blocking, from code review)
- **WR-01**: an unresolvable SF-held forward ref (typo / unregistered / `init_with_rapyer=False` target) is silently dropped — no edge, no startup error, cascade silently off. Consider wiring into the fail-fast path.
- **WR-02**: `RedisSet` validates members without the redis context while `RedisPriorityQueue` validates with it; harmless today, risks divergence for a future context-sensitive inner type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWA2KXKFrqLo5qnhDC3ACi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TTL cascades now follow references stored in Redis sets and priority queues.
  * Parent saves and cascading TTL updates refresh eligible referenced records.
  * Cascade handling supports nested references, collections, self-references, and shared targets.
  * Reference values in Redis containers are validated before storage.

* **Bug Fixes**
  * Improved handling of forward and nested reference definitions.
  * Clarified fakeredis behavior: container TTLs refresh, but contained members are not traversed.

* **Documentation**
  * Added guidance on cascade-eligible reference shapes and TTL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->