### PR TITLE
feat: multi-class FK cascade reach through union / polymorphic-base targets (#262)

### DIFF
--- a/docs/documentation/special-fields/ttl-cascade.md
+++ b/docs/documentation/special-fields/ttl-cascade.md
@@ -130,6 +130,116 @@ await library.aset_ttl(3600, cascade=True)
 The same applies to a `RedisPriorityQueue[Reference[Author]]` field: members added via
 `apush` are reached the same way and re-armed to their own `Meta.ttl`.
 
+### Multi-Class FK Targets (Union / Polymorphic Base)
+
+A `Reference` FK does not have to point at a single concrete class. Cascade fully
+supports two multi-class shapes, in every FK shape above (scalar, collection, and
+special-field-held):
+
+- **Union targets** — `Reference[A | B]`, where the stored key may point at *either*
+  concrete class.
+- **Polymorphic base targets** — `Reference[Base]`, where `Base` has registered
+  subclasses and the stored key may point at the base itself *or* any subclass.
+
+In both cases the edge carries **all** candidate classes, and the cascade resolves
+each reached child's *actual* class at traversal time from its stored key's
+`{class}:{pk}` prefix, then re-arms that child to **its own** resolved class's
+`Meta.ttl` — exactly as with a single-target FK. A child whose class is a valid model
+but is *not* among the edge's candidates is skipped (never re-armed) and counted as
+class drift in `CascadeResult.mismatched_class`.
+
+The single runnable example below shows **both** shapes — a union FK and a
+polymorphic-base FK — each re-arming its reached child to that child's own `Meta.ttl`:
+
+```python
+from typing import Annotated, ClassVar
+
+from rapyer import AtomicRedisModel
+from rapyer.cascade import CascadeTTL
+from rapyer.config import RedisConfig
+from rapyer.types import Reference
+
+
+# --- Union target: the FK may point at EITHER concrete class ---
+class Author(AtomicRedisModel):
+    name: str = "anon"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+class Editor(AtomicRedisModel):
+    name: str = "anon"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=1800)
+
+
+class Article(AtomicRedisModel):
+    # A single FK whose target is a UNION of two concrete models; the edge
+    # carries BOTH Author and Editor as candidate targets.
+    contributor: Annotated[Reference[Author | Editor], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+# --- Polymorphic base target: the FK targets a base with registered subclasses ---
+class Shape(AtomicRedisModel):
+    label: str = "shape"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+class Circle(Shape):
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=600)
+
+
+class Square(Shape):
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=900)
+
+
+class Canvas(AtomicRedisModel):
+    # A single FK to a polymorphic BASE; the edge carries the base AND every
+    # registered subclass (Shape, Circle, Square) as candidate targets.
+    root: Annotated[Reference[Shape], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=3600)
+
+
+# ... after init_rapyer(redis) with all of the models above registered:
+
+# Union edge: point the FK at an Editor, then cascade-refresh the owner.
+editor = await Editor(name="Jane").asave()
+article = await Article(contributor=editor.key).asave()
+await article.aset_ttl(3600, cascade=True)
+# The reached Editor is re-armed to ITS OWN Meta.ttl (1800s) -- its class is
+# resolved from the stored key's "Editor:<pk>" prefix, NOT set to Article's 3600s.
+
+# Polymorphic edge: point the base FK at a concrete Circle subclass instance.
+circle = await Circle(label="c").asave()
+canvas = await Canvas(root=circle.key).asave()
+await canvas.aset_ttl(3600, cascade=True)
+# The reached Circle is re-armed to Circle.Meta.ttl (600s) -- the concrete subclass
+# is resolved from the "Circle:<pk>" key prefix, even though the edge is declared
+# against the Shape base.
+```
+
+!!! warning "Class identity is resolved from the `{class}:{pk}` key prefix"
+    Multi-class cascade resolves each reached child's class at traversal time from
+    its stored key's `{class}:{pk}` prefix (split on the **first** colon) and matches
+    it against the edge's candidate classes. Two constraints make this reliable, both
+    enforced up front at `init_rapyer()` time:
+
+    - **`class_key_initials()` must equal `__name__`** for every cascade participant
+      (the root, every edge target, and every reachable candidate). The cascade plan
+      keys its candidates by `__name__`, but the real Redis key prefix comes from
+      `class_key_initials()`. Overriding `class_key_initials()` to anything other than
+      `__name__` would make a reached child's prefix never match a candidate — a
+      silent, mis-keyed cascade. `init_rapyer()` refuses to start and raises
+      **`CascadeKeyInitialsError`**, naming the offending model, its overridden
+      initials, and its `__name__`, rather than allowing that silent failure.
+    - **Class names must be unique** across all registered models, so a `{class}`
+      prefix maps to exactly one model. This is already enforced at registration by
+      **`DuplicateModelNameError`** — no separate cascade check is needed.
+
 ## Precedence
 
 Cascade eligibility for a given `Reference` field is resolved in this order:

--- a/rapyer/base.py
+++ b/rapyer/base.py
@@ -622,7 +622,9 @@ class AtomicRedisModel(BaseModel):
                 await pipe.execute()
                 if not cascade:
                     return None
-                return CascadeResult(dangling_children=0, dangling_special=0)
+                return CascadeResult(
+                    dangling_children=0, dangling_special=0, mismatched_class=0
+                )
             # `cascade` is a per-call flag: 0 = root's own keys only, 1 = walk the graph.
             scripts_registry.run_fcall(
                 pipe,
@@ -641,9 +643,11 @@ class AtomicRedisModel(BaseModel):
         if not cascade:
             # Matches the old plain-EXPIRE contract: a non-cascading call returns None.
             return None
-        dangling_children, dangling_special = results[-1]
+        dangling_children, dangling_special, mismatched_class = results[-1]
         return CascadeResult(
-            dangling_children=dangling_children, dangling_special=dangling_special
+            dangling_children=dangling_children,
+            dangling_special=dangling_special,
+            mismatched_class=mismatched_class,
         )
 
     @functools.cached_property

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -5,7 +5,11 @@ from types import UnionType
 from typing import TYPE_CHECKING, Any, ForwardRef, Union, get_args, get_origin
 
 from rapyer.cascade.ttl import CascadeTTL
-from rapyer.errors.cascade import CascadeLuaLiteralError, CascadeTargetTtlMissingError
+from rapyer.errors.cascade import (
+    CascadeKeyInitialsError,
+    CascadeLuaLiteralError,
+    CascadeTargetTtlMissingError,
+)
 from rapyer.scripts.constants import CASCADE_FUNCTION_PREFIX, CASCADE_LIBRARY_PREFIX
 from rapyer.types.relational import RelationalFieldType
 from rapyer.utils.annotation import strip_optional
@@ -47,6 +51,15 @@ def _unwrap_relational_target(annotation: Any, models: list) -> list:
     (a collection/SF wrapper around a union must not drop members), and the
     result is order-preserving and de-duplicated. An empty list means the
     annotation is not FK-shaped.
+
+    Candidates are keyed by ``cls.__name__`` (D-04). At traversal time the
+    reached child's class is resolved from its real ``{class}:{pk}`` key prefix
+    and membership-checked against these names, so a cascade participant's
+    ``class_key_initials()`` MUST equal ``__name__`` — otherwise the reached
+    prefix never matches a candidate and the cascade silently dead-ends. That
+    equality is enforced at init by ``validate_cascade_key_initials``; class-name
+    uniqueness is separately guaranteed at registration by
+    ``DuplicateModelNameError``.
     """
     stripped = strip_optional(annotation)
     origin = get_origin(stripped) or stripped
@@ -114,6 +127,11 @@ class CascadeEdge:
     # Every candidate target class name for a multi-class edge (union / polymorphic
     # base). None (dropped by _drop_none_values) for a single-target edge, which
     # keeps its plan JSON byte-for-byte identical; when set, candidates[0] == target.
+    # D-04: these names are ``cls.__name__``. Traversal resolves a reached child's
+    # class from its ``{class}:{pk}`` key prefix and membership-checks it here, so a
+    # participant's ``class_key_initials()`` MUST equal ``__name__`` (enforced by
+    # ``validate_cascade_key_initials``); class-name uniqueness is separately
+    # guaranteed at registration by ``DuplicateModelNameError``.
     candidates: list[str] | None = None
 
 
@@ -346,6 +364,58 @@ def validate_cascade_ttl_targets(plan: dict[str, CascadePlanEntry]):
                 f"{class_name!r} has outgoing cascade-enabled edges (it is a "
                 "cascade root) but declares no Meta.ttl; the cascade would "
                 "EXPIRE its own key with a nil ttl",
+            )
+
+
+def validate_cascade_key_initials(models: list[type["AtomicRedisModel"]]):
+    """Raise CascadeKeyInitialsError when a cascade participant overrides
+    class_key_initials() to a value other than __name__ (D-02).
+
+    The cascade plan and ``edge.candidates`` are keyed by ``cls.__name__``, but
+    the real Redis key prefix is ``class_key_initials()``. Reached-key class
+    resolution (``library.lua`` ``push_child``) splits the ``{class}:{pk}``
+    prefix and matches it against those ``__name__``-keyed candidates, so a
+    participant whose ``class_key_initials() != __name__`` stores its keys under
+    a prefix the traversal can never match — silently mis-resolving or
+    dead-ending the cascade. This turns that silent no-op into a loud fail-fast
+    at ``init_rapyer()``.
+
+    Scope is every model that participates in the built cascade plan: each root
+    (a plan entry with outgoing edges) plus every ``edge.target`` /
+    ``edge.candidates`` member reachable via an edge. The check is pure config
+    time — it builds the static plan and calls ``class_key_initials()``, doing
+    NO Redis I/O, mirroring ``validate_cascade_ttl_targets``.
+
+    Class-name uniqueness across participants is NOT re-checked here; it is
+    already enforced at registration by ``DuplicateModelNameError``. This guard
+    checks only the initials-vs-``__name__`` equality.
+    """
+    plan = build_cascade_plan(models)
+    participant_names: set[str] = set()
+    for class_name, entry in plan.items():
+        if entry.fks:
+            # A cascade root: it EXPIREs its own key, so its prefix is load-bearing.
+            participant_names.add(class_name)
+        for edge in entry.fks:
+            # Single-target edges carry candidates=None -> [edge.target].
+            for target in edge.candidates or [edge.target]:
+                participant_names.add(target)
+
+    models_by_name = {model.__name__: model for model in models}
+    for name in sorted(participant_names):
+        cls = models_by_name.get(name)
+        if cls is None:
+            # A missing target is validate_cascade_ttl_targets' concern; skip here.
+            continue
+        initials = cls.class_key_initials()
+        if initials != cls.__name__:
+            raise CascadeKeyInitialsError(
+                cls.__name__,
+                f"{cls.__name__!r} participates in the cascade plan but its "
+                f"class_key_initials() returns {initials!r}, not its __name__ "
+                f"{cls.__name__!r}; cascade class resolution matches the reached "
+                "key's {class}:{pk} prefix against __name__-keyed candidates, so "
+                "an override would silently mis-resolve or dead-end the cascade",
             )
 
 

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -1,7 +1,8 @@
 import dataclasses
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, ForwardRef, get_origin
+from types import UnionType
+from typing import TYPE_CHECKING, Any, ForwardRef, Union, get_args, get_origin
 
 from rapyer.cascade.ttl import CascadeTTL
 from rapyer.errors.cascade import CascadeLuaLiteralError, CascadeTargetTtlMissingError
@@ -38,21 +39,54 @@ def _resolve_forward_ref(forward_ref: ForwardRef) -> Any | None:
     return None
 
 
-def _unwrap_relational_target(annotation: Any) -> Any | None:
-    """Return the model class an FK-shaped annotation points to, or None."""
+def _unwrap_relational_target(annotation: Any, models: list) -> list:
+    """Return every candidate model class an FK-shaped annotation points to.
+
+    A single-target FK returns a one-element list; a union ``Reference[A | B]``
+    returns one entry per member. The recursion ACCUMULATES across generic args
+    (a collection/SF wrapper around a union must not drop members), and the
+    result is order-preserving and de-duplicated. An empty list means the
+    annotation is not FK-shaped.
+    """
     stripped = strip_optional(annotation)
     origin = get_origin(stripped) or stripped
     if safe_issubclass(origin, RelationalFieldType):
         args = resolve_generic_args(stripped)
         target = args[0] if args else None
-        if isinstance(target, ForwardRef):
-            return _resolve_forward_ref(target)
-        return target
+        if target is None:
+            return []
+        if get_origin(target) in (Union, UnionType):
+            members = get_args(target)
+        else:
+            members = (target,)
+        candidates: list = []
+        for member in members:
+            resolved = (
+                _resolve_forward_ref(member)
+                if isinstance(member, ForwardRef)
+                else member
+            )
+            if resolved is None:
+                continue
+            for candidate in _expand_candidates(resolved, models):
+                if candidate not in candidates:
+                    candidates.append(candidate)
+        return candidates
+    accumulated: list = []
     for arg in resolve_generic_args(stripped):
-        found = _unwrap_relational_target(arg)
-        if found is not None:
-            return found
-    return None
+        for candidate in _unwrap_relational_target(arg, models):
+            if candidate not in accumulated:
+                accumulated.append(candidate)
+    return accumulated
+
+
+def _expand_candidates(target_cls: Any, models: list) -> list:
+    """Candidate classes contributed by one resolved FK target class.
+
+    Phase-1 tracer: enumerate the resolved class verbatim (concrete leaf).
+    Subclass expansion over the threaded ``models`` list is added in Task 2.
+    """
+    return [target_cls]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -72,6 +106,10 @@ class CascadeEdge:
     depth: int | None = None
     # None = inline; "set"/"zset" = FK held in a RedisSet/PQ, path is then the SF key suffix.
     sf_container: str | None = None
+    # Every candidate target class name for a multi-class edge (union / polymorphic
+    # base). None (dropped by _drop_none_values) for a single-target edge, which
+    # keeps its plan JSON byte-for-byte identical; when set, candidates[0] == target.
+    candidates: list[str] | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -107,9 +145,9 @@ def _classify_edge(model_cls: Any, field_name: str) -> EdgeClassification:
     return EdgeClassification(enabled=True, depth=global_spec.depth, override=False)
 
 
-def _resolve_target_cls(model_cls: Any, field_name: str) -> Any | None:
+def _resolve_target_cls(model_cls: Any, field_name: str, models: list) -> list:
     annotation = model_cls.model_fields[field_name].annotation
-    return _unwrap_relational_target(annotation)
+    return _unwrap_relational_target(annotation, models)
 
 
 def _unwrap_nested_model_cls(annotation: Any) -> Any | None:
@@ -123,27 +161,34 @@ def _unwrap_nested_model_cls(annotation: Any) -> Any | None:
 
 
 def _static_walk_fk_edges(
-    model_cls: Any, parent_path: str, fks: list[CascadeEdge], top_level: bool = True
+    model_cls: Any,
+    parent_path: str,
+    fks: list[CascadeEdge],
+    models: list,
+    top_level: bool = True,
 ):
     """Append every enabled FK edge reachable from model_cls's own fields."""
     for field_name in model_cls._relational_field_names:
         edge = _classify_edge(model_cls, field_name)
         if not edge.enabled:
             continue
-        target_cls = _resolve_target_cls(model_cls, field_name)
-        if target_cls is None:
+        cands = _resolve_target_cls(model_cls, field_name, models)
+        if not cands:
             continue
         # A per-field spec resets the child's budget to this depth; a global edge decrements it.
         fks.append(
             CascadeEdge(
                 path=f"{parent_path}.{field_name}",
-                target=target_cls.__name__,
+                target=cands[0].__name__,
                 is_collection=False,
                 recurse_into_target=True,
                 refresh_target_ttl=True,
                 refresh_target_special_keys=True,
                 resets_depth_budget=edge.override,
                 depth=edge.depth,
+                candidates=(
+                    [c.__name__ for c in cands] if len(cands) > 1 else None
+                ),
             )
         )
 
@@ -153,7 +198,9 @@ def _static_walk_fk_edges(
         if nested_cls is not None:
             # Nested inline sub-model: same RedisJSON document, zero-hop recursion.
             nested_path = f"{parent_path}.{field_name}"
-            _static_walk_fk_edges(nested_cls, nested_path, fks, top_level=False)
+            _static_walk_fk_edges(
+                nested_cls, nested_path, fks, models, top_level=False
+            )
             continue
 
         sf_container = _sf_container_kind(annotation)
@@ -164,13 +211,13 @@ def _static_walk_fk_edges(
             edge = _classify_edge(model_cls, field_name)
             if not edge.enabled:
                 continue
-            target_cls = _unwrap_relational_target(annotation)
-            if target_cls is None:
+            cands = _unwrap_relational_target(annotation, models)
+            if not cands:
                 continue
             fks.append(
                 CascadeEdge(
                     path=field_name,
-                    target=target_cls.__name__,
+                    target=cands[0].__name__,
                     is_collection=True,
                     recurse_into_target=True,
                     refresh_target_ttl=True,
@@ -178,6 +225,9 @@ def _static_walk_fk_edges(
                     resets_depth_budget=edge.override,
                     depth=edge.depth,
                     sf_container=sf_container,
+                    candidates=(
+                        [c.__name__ for c in cands] if len(cands) > 1 else None
+                    ),
                 )
             )
             continue
@@ -186,19 +236,22 @@ def _static_walk_fk_edges(
         edge = _classify_edge(model_cls, field_name)
         if not edge.enabled:
             continue
-        target_cls = _resolve_target_cls(model_cls, field_name)
-        if target_cls is None:
+        cands = _resolve_target_cls(model_cls, field_name, models)
+        if not cands:
             continue
         fks.append(
             CascadeEdge(
                 path=f"{parent_path}.{field_name}",
-                target=target_cls.__name__,
+                target=cands[0].__name__,
                 is_collection=True,
                 recurse_into_target=True,
                 refresh_target_ttl=True,
                 refresh_target_special_keys=True,
                 resets_depth_budget=edge.override,
                 depth=edge.depth,
+                candidates=(
+                    [c.__name__ for c in cands] if len(cands) > 1 else None
+                ),
             )
         )
 
@@ -248,7 +301,7 @@ def build_cascade_plan(
     plan: dict[str, CascadePlanEntry] = {}
     for model_cls in models:
         fks: list[CascadeEdge] = []
-        _static_walk_fk_edges(model_cls, "$", fks)
+        _static_walk_fk_edges(model_cls, "$", fks, models)
         plan[model_cls.__name__] = CascadePlanEntry(
             ttl=model_cls.Meta.ttl,
             special_suffixes=_static_walk_special_suffixes(model_cls),
@@ -261,23 +314,25 @@ def validate_cascade_ttl_targets(plan: dict[str, CascadePlanEntry]):
     """Raise CascadeTargetTtlMissingError when a cascade participant lacks a Meta.ttl."""
     for class_name, entry in sorted(plan.items()):
         for edge in entry.fks:
-            target = edge.target
-            # A partial plan may omit a target; surface a RapyerError, not a bare KeyError.
-            target_entry = plan.get(target)
-            if target_entry is None:
-                raise CascadeTargetTtlMissingError(
-                    target,
-                    f"{target!r} is reachable via a cascade-enabled edge from "
-                    f"{class_name!r} (path {edge.path!r}) but is absent from "
-                    "the cascade plan",
-                )
-            if target_entry.ttl is None:
-                raise CascadeTargetTtlMissingError(
-                    target,
-                    f"{target!r} is reachable via a cascade-enabled edge "
-                    f"from {class_name!r} (path {edge.path!r}) but "
-                    "declares no Meta.ttl",
-                )
+            # Validate EVERY candidate of a multi-class edge (single-target edges
+            # carry candidates=None, so this loops once over [edge.target]).
+            for target in edge.candidates or [edge.target]:
+                # A partial plan may omit a target; surface a RapyerError, not a bare KeyError.
+                target_entry = plan.get(target)
+                if target_entry is None:
+                    raise CascadeTargetTtlMissingError(
+                        target,
+                        f"{target!r} is reachable via a cascade-enabled edge from "
+                        f"{class_name!r} (path {edge.path!r}) but is absent from "
+                        "the cascade plan",
+                    )
+                if target_entry.ttl is None:
+                    raise CascadeTargetTtlMissingError(
+                        target,
+                        f"{target!r} is reachable via a cascade-enabled edge "
+                        f"from {class_name!r} (path {edge.path!r}) but "
+                        "declares no Meta.ttl",
+                    )
 
     for class_name, entry in sorted(plan.items()):
         if entry.fks and entry.ttl is None:

--- a/rapyer/cascade/planner.py
+++ b/rapyer/cascade/planner.py
@@ -81,12 +81,17 @@ def _unwrap_relational_target(annotation: Any, models: list) -> list:
 
 
 def _expand_candidates(target_cls: Any, models: list) -> list:
-    """Candidate classes contributed by one resolved FK target class.
+    """Candidate classes contributed by one resolved FK target class:
+    ``{target_cls} ∪ {registered subclasses of target_cls}``.
 
-    Phase-1 tracer: enumerate the resolved class verbatim (concrete leaf).
-    Subclass expansion over the threaded ``models`` list is added in Task 2.
+    Enumerated over the THREADED ``models`` list (Option B) for test hermeticity.
+    Because ``safe_issubclass(T, T)`` is True, the base is included iff it is
+    itself registered in ``models`` (Decision #3: an abstract, unregistered base
+    carries no Meta.ttl and must stay out of the candidate set). The resolved
+    class leads, then its subclasses in declaration order; the caller
+    de-duplicates across union members.
     """
-    return [target_cls]
+    return [m for m in models if safe_issubclass(m, target_cls)]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/rapyer/errors/__init__.py
+++ b/rapyer/errors/__init__.py
@@ -14,6 +14,7 @@ from rapyer.errors.base import (
     UpdateAtomicModelError,
 )
 from rapyer.errors.cascade import (
+    CascadeKeyInitialsError,
     CascadeLuaLiteralError,
     CascadeTargetTtlMissingError,
     InvalidCascadeDepthError,
@@ -47,6 +48,7 @@ __all__ = [
     "BadDeleteActionError",
     "BadFilterError",
     "CantSerializeRedisValueError",
+    "CascadeKeyInitialsError",
     "CascadeLuaLiteralError",
     "CascadeTargetTtlMissingError",
     "CorruptedModelError",

--- a/rapyer/errors/cascade.py
+++ b/rapyer/errors/cascade.py
@@ -13,6 +13,24 @@ class CascadeTargetTtlMissingError(RapyerError):
         self.model_name = model_name
 
 
+class CascadeKeyInitialsError(RapyerError):
+    """Raised at init_rapyer() when a cascade participant overrides
+    class_key_initials() to a value other than __name__.
+
+    The cascade plan and ``edge.candidates`` are keyed by ``cls.__name__``, but
+    the real Redis key prefix is ``class_key_initials()`` (an overridable
+    classmethod defaulting to ``__name__``). Reached-key class resolution splits
+    the ``{class}:{pk}`` prefix and matches it against those ``__name__``-keyed
+    candidates, so an override ``!= __name__`` would silently mis-resolve or
+    dead-end the cascade. Carries the offending ``model_name`` like
+    CascadeTargetTtlMissingError.
+    """
+
+    def __init__(self, model_name: str, *args):
+        super().__init__(*args)
+        self.model_name = model_name
+
+
 class MetaFrozenError(RapyerError):
     """Raised when Meta config is mutated after init_rapyer() has baked the cascade plan against it."""
 

--- a/rapyer/init.py
+++ b/rapyer/init.py
@@ -9,6 +9,7 @@ from rapyer.cascade import CascadeTTL
 from rapyer.cascade.planner import (
     build_cascade_plan,
     cascade_plan_json,
+    validate_cascade_key_initials,
     validate_cascade_ttl_targets,
 )
 from rapyer.result import resolve_forward_refs
@@ -83,6 +84,10 @@ async def init_rapyer(
         # registered. Pure config check; needs no Redis connection.
         plan = build_cascade_plan(REDIS_MODELS)
         validate_cascade_ttl_targets(plan)
+        # A cascade participant overriding class_key_initials() != __name__ would
+        # silently mis-resolve at traversal time; fail fast here (D-02). Needs the
+        # model CLASSES to call class_key_initials(); no Redis I/O.
+        validate_cascade_key_initials(REDIS_MODELS)
     finally:
         # Refreeze now that the plan is baked; further Meta mutation is blocked
         # until the next init_rapyer() call. Runs even on failure.

--- a/rapyer/result.py
+++ b/rapyer/result.py
@@ -34,6 +34,11 @@ class RapyerDeleteResult(DeleteResult):
 class CascadeResult(BaseModel):
     dangling_children: int
     dangling_special: int
+    # Count of MULTI-CLASS reaches whose resolved class was not among the edge's
+    # candidate targets (or was absent from the plan) -- server-side class-drift
+    # observability (D-03). Defaulted to 0 so existing construction sites stay
+    # forward-compatible; the Lua/apply lockstep sites set it explicitly.
+    mismatched_class: int = 0
 
 
 class GetOrCreateStatus(str, Enum):

--- a/rapyer/scripts/lua/cascade/library.lua
+++ b/rapyer/scripts/lua/cascade/library.lua
@@ -176,6 +176,14 @@ local function cascade_apply(keys, args)
     local pending_refresh = {}
     local refresh_order = {}
     local stack = {}
+    -- Per-call drift counter (D-03): incremented in push_child whenever a
+    -- MULTI-CLASS reach resolves to a class that is NOT one of the edge's
+    -- candidates (or is absent from the plan). Declared here beside visited/
+    -- stack -- a cascade_apply-scope local, NEVER library scope -- because it is
+    -- per-call mutable state; hoisting it would leak across FCALLs (see the
+    -- callback header contract above). Returned as the third element of the
+    -- write-phase tuple so the Python apply layer can surface class drift.
+    local mismatched_class = 0
 
     local function queue_refresh(full_key, class_name, is_root, is_special)
         is_root = is_root or false
@@ -202,7 +210,57 @@ local function cascade_apply(keys, args)
     end
 
     local function push_child(target_key, edge, budget)
-        if type(target_key) == 'string' and budget_is_larger(budget, visited[target_key]) then
+        if type(target_key) ~= 'string' then
+            return
+        end
+        -- Resolve the reached child's ACTUAL class.
+        --
+        -- Single-target edge (edge.candidates absent): the edge already carries
+        -- its one target's class name, so the class is read straight from the
+        -- plan, NEVER parsed back out of the key. This keeps the single-target
+        -- path byte-identical and parse-free (D-01 / CMCT-09).
+        --
+        -- Multi-class edge (edge.candidates present -- a union or polymorphic-
+        -- base FK): the child's class is resolved from its own key's
+        -- {class}:{pk} prefix, split on the FIRST colon via
+        -- string.match(target_key, '^([^:]+):'). The negated character class
+        -- [^:]+ stops at the first colon, mirroring the Python key.setter's
+        -- value.split(':', maxsplit=1) in base.py, so a Key[...] pk that itself
+        -- carries a ':' still resolves to the correct class prefix. Class
+        -- identity IS the key prefix; membership is EXACT string equality
+        -- against this edge's candidate set.
+        local resolved_class = edge.target
+        if edge.candidates then
+            local prefix = string.match(target_key, '^([^:]+):')
+            if prefix == nil then
+                -- No colon / unparseable prefix: a silent, UNCOUNTED dead-end,
+                -- reusing the corrupt/WRONGTYPE reach contract's skip ACTION.
+                -- Never tallied as class drift (a corrupt reach is not drift).
+                return
+            end
+            local is_candidate = false
+            for _, name in ipairs(edge.candidates) do
+                if name == prefix then
+                    is_candidate = true
+                    break
+                end
+            end
+            if not is_candidate or CASCADE_PLAN[prefix] == nil then
+                -- Resolved to a class that is NOT one of this edge's candidates
+                -- (or is absent from the plan): class drift. Skip -- no refresh,
+                -- no recursion -- and tally it so the caller can observe a
+                -- misconfigured graph (D-03). validate_cascade_ttl_targets
+                -- guarantees every candidate has a plan entry, so these two
+                -- sub-cases fold into one branch. Counted at REACH time
+                -- (at-least-once, NOT deduped via the visited map): the
+                -- requirement is observability of drift, not exact-once
+                -- accounting.
+                mismatched_class = mismatched_class + 1
+                return
+            end
+            resolved_class = prefix
+        end
+        if budget_is_larger(budget, visited[target_key]) then
             -- Record the new best budget at PUSH time (not pop time) so a later,
             -- even-larger push for the same key is still correctly detected
             -- against the latest recorded best, and a smaller push arriving
@@ -210,10 +268,7 @@ local function cascade_apply(keys, args)
             visited[target_key] = budget
             stack[#stack + 1] = {
                 key = target_key,
-                -- The edge already carries its target's class name, so the
-                -- child's class is read straight from the plan, never parsed
-                -- back out of the key.
-                class = edge.target,
+                class = resolved_class,
                 edge = edge,
                 budget = budget,
                 -- A child's subtree is always established: it was entered via a
@@ -385,7 +440,7 @@ local function cascade_apply(keys, args)
         end
     end
 
-    return {dangling_children_count, dangling_special_count}
+    return {dangling_children_count, dangling_special_count, mismatched_class}
 end
 
 redis.register_function('RAPYER_CASCADE_FN', cascade_apply)

--- a/tests/integration/foreign_keys/test_cascade_depth_and_gate.py
+++ b/tests/integration/foreign_keys/test_cascade_depth_and_gate.py
@@ -71,7 +71,8 @@ async def test_cascade_false_still_refreshes_roots_own_special_keys(real_redis_c
         )
         > 0
     )
-    assert result == [0, 0]
+    # Third element is the D-03 mismatched_class counter, 0 for a single-target reach.
+    assert result == [0, 0, 0]
 
 
 # --- Dangling-count contract ---
@@ -91,7 +92,7 @@ async def test_cascade_counts_fully_dangling_child_and_its_special_keys(
     result = await apply_cascade(real_redis_client, parent)
 
     # Assert
-    assert result == [1, 2]
+    assert result == [1, 2, 0]
 
 
 @pytest.mark.asyncio
@@ -108,7 +109,7 @@ async def test_cascade_counts_dangling_special_keys_on_an_existing_child(
     result = await apply_cascade(real_redis_client, parent)
 
     # Assert
-    assert result == [0, 2]
+    assert result == [0, 2, 0]
 
 
 # --- Depth-budget arithmetic ---

--- a/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
@@ -1,0 +1,39 @@
+import pytest
+
+from rapyer.result import CascadeResult
+from tests.models.cascade_types import (
+    CASCADE_FIXTURE_TTL_SECONDS,
+    CascadeUnionMemberA,
+    CascadeUnionOwner,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
+
+
+@pytest.mark.asyncio
+async def test_scalar_union_reaches_resolved_member_class(real_redis_client):
+    # Arrange
+    # The phase tracer: ONE scalar-union FK owner referencing a concrete member.
+    # The reached member's class is NOT baked into the edge (the edge carries
+    # BOTH CascadeUnionMemberA/B as candidates); it must be resolved server-side
+    # from the reached key's {class}:{pk} prefix, membership-checked against the
+    # edge's candidates, and re-armed to its OWN resolved class's Meta.ttl --
+    # all driven through the PUBLIC aset_ttl(cascade=True) API on real Redis.
+    member = await CascadeUnionMemberA(name="reached").asave()
+    owner = await CascadeUnionOwner(ref=member.key).asave()
+    await real_redis_client.persist(owner.key)
+    await real_redis_client.persist(member.key)
+
+    # Act
+    result = await owner.aset_ttl(CASCADE_FIXTURE_TTL_SECONDS, cascade=True)
+
+    # Assert
+    # A clean union reach: zero danglings, zero class drift, and the reached
+    # member re-armed (ttl > 0) to its own class's Meta.ttl. This exercises the
+    # D-01 push_child resolution branch, the D-03 mismatched_class counter, the
+    # base.py 3-element results[-1] unpack, and the result.py field together,
+    # end-to-end through the public API.
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
+    assert await real_redis_client.ttl(member.key) > 0

--- a/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
@@ -1,10 +1,18 @@
 import pytest
 
 from rapyer.result import CascadeResult
+from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
     CASCADE_FIXTURE_TTL_SECONDS,
+    CascadeColonPkMember,
+    CascadeColonPkOwner,
+    CascadeUnionDictOwner,
+    CascadeUnionListOwner,
     CascadeUnionMemberA,
+    CascadeUnionMemberB,
     CascadeUnionOwner,
+    CascadeUnionPQOwner,
+    CascadeUnionSetOwner,
 )
 
 pytestmark = pytest.mark.usefixtures("setup_real_redis_for_cascade_apply")
@@ -37,3 +45,185 @@ async def test_scalar_union_reaches_resolved_member_class(real_redis_client):
         dangling_children=0, dangling_special=0, mismatched_class=0
     )
     assert await real_redis_client.ttl(member.key) > 0
+
+
+# --- Task 1: both candidates resolve from the SAME union edge (CMCT-04 adjacency) ---
+
+
+@pytest.mark.asyncio
+async def test_scalar_union_both_members_resolve_and_rearm_from_the_same_edge(
+    real_redis_client,
+):
+    # Arrange
+    # ONE union edge (CascadeUnionOwner.ref, candidates == {A, B}) reached by two
+    # owners -- one pointing at a member-A key, one at a member-B key. The reached
+    # class is NOT baked into the edge; each is resolved server-side from its own
+    # {class}:{pk} prefix and EXACT-matched against the shared candidate set. This
+    # proves BOTH union members resolve correctly from the same edge, not just the
+    # first candidate.
+    member_a = await CascadeUnionMemberA(name="a").asave()
+    member_b = await CascadeUnionMemberB(name="b").asave()
+    owner_a = await CascadeUnionOwner(ref=member_a.key).asave()
+    owner_b = await CascadeUnionOwner(ref=member_b.key).asave()
+    for key in (owner_a.key, owner_b.key, member_a.key, member_b.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result_a = await apply_cascade(real_redis_client, owner_a)
+    result_b = await apply_cascade(real_redis_client, owner_b)
+
+    # Assert
+    # Member A re-arms from the A-prefix reach; member B re-arms from the B-prefix
+    # reach -- exact-prefix membership resolves both candidates, no class drift.
+    assert await real_redis_client.ttl(member_a.key) > 0
+    assert await real_redis_client.ttl(member_b.key) > 0
+    assert result_a[2] == 0
+    assert result_b[2] == 0
+
+
+# --- Task 1: collection-of-union shapes (list / dict) re-arm every referenced member ---
+
+
+@pytest.mark.asyncio
+async def test_list_union_owner_rearms_every_referenced_member_class(real_redis_client):
+    # Arrange
+    # A list[Reference[A | B]] whose elements MIX both member classes. Every
+    # referenced member must resolve from its own key prefix and re-arm to its
+    # OWN class's Meta.ttl (CMCT-04/05/07 collection shape).
+    member_a = await CascadeUnionMemberA(name="la").asave()
+    member_b = await CascadeUnionMemberB(name="lb").asave()
+    owner = await CascadeUnionListOwner(refs=[member_a.key, member_b.key]).asave()
+    for key in (owner.key, member_a.key, member_b.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    for key in (owner.key, member_a.key, member_b.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result[2] == 0
+
+
+@pytest.mark.asyncio
+async def test_dict_union_owner_rearms_every_referenced_member_class(real_redis_client):
+    # Arrange
+    # A dict[str, Reference[A | B]] whose values MIX both member classes.
+    member_a = await CascadeUnionMemberA(name="da").asave()
+    member_b = await CascadeUnionMemberB(name="db").asave()
+    owner = await CascadeUnionDictOwner(
+        refs={"x": member_a.key, "y": member_b.key}
+    ).asave()
+    for key in (owner.key, member_a.key, member_b.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    for key in (owner.key, member_a.key, member_b.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result[2] == 0
+
+
+# --- Task 1: SF-held union shapes (RedisSet / RedisPriorityQueue) re-arm both classes ---
+
+
+@pytest.mark.asyncio
+async def test_set_union_owner_rearms_both_member_classes(real_redis_client):
+    # Arrange
+    # An SF-held RedisSet[Reference[A | B]] holding one member-A key and one
+    # member-B key. Both members are reached via the SMEMBERS branch, each
+    # resolved from its own prefix and re-armed (CMCT-04/07 SF-set shape).
+    member_a = await CascadeUnionMemberA(name="sa").asave()
+    member_b = await CascadeUnionMemberB(name="sb").asave()
+    owner = await CascadeUnionSetOwner().asave()
+    await owner.refs.aadd(member_a.key)
+    await owner.refs.aadd(member_b.key)
+    for key in (owner.key, member_a.key, member_b.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    for key in (owner.key, member_a.key, member_b.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result[2] == 0
+
+
+@pytest.mark.asyncio
+async def test_priority_queue_union_owner_rearms_both_member_classes(
+    real_redis_client,
+):
+    # Arrange
+    # An SF-held RedisPriorityQueue[Reference[A | B]] holding both member classes.
+    # Both are reached via the ZRANGE branch, resolved, and re-armed
+    # (CMCT-04/07 SF-priority-queue shape).
+    member_a = await CascadeUnionMemberA(name="pa").asave()
+    member_b = await CascadeUnionMemberB(name="pb").asave()
+    owner = await CascadeUnionPQOwner().asave()
+    await owner.queue.apush(member_a.key, priority=1.0)
+    await owner.queue.apush(member_b.key, priority=2.0)
+    for key in (owner.key, member_a.key, member_b.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    for key in (owner.key, member_a.key, member_b.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result[2] == 0
+
+
+# --- Task 1: empty union owners reach no child and never crash (CMCT-07 empty) ---
+
+
+@pytest.mark.asyncio
+async def test_empty_union_owners_reach_no_child_and_do_not_crash(real_redis_client):
+    # Arrange
+    # Every union FK shape with an EMPTY container: a scalar-less collection, an
+    # empty RedisSet, and an empty RedisPriorityQueue. Each must complete the
+    # FCALL, re-arm its own root key, reach no child, and never raise.
+    list_owner = await CascadeUnionListOwner().asave()
+    dict_owner = await CascadeUnionDictOwner().asave()
+    set_owner = await CascadeUnionSetOwner().asave()
+    pq_owner = await CascadeUnionPQOwner().asave()
+    owners = (list_owner, dict_owner, set_owner, pq_owner)
+    for owner in owners:
+        await real_redis_client.persist(owner.key)
+
+    # Act / Assert (no child reached, root re-armed, zero class drift, no crash)
+    for owner in owners:
+        result = await apply_cascade(real_redis_client, owner)
+        assert await real_redis_client.ttl(owner.key) > 0
+        assert result[2] == 0
+
+
+# --- Task 1: colon-bearing pk resolves via first-colon split (Pitfall 2) ---
+
+
+@pytest.mark.asyncio
+async def test_colon_bearing_pk_member_resolves_via_first_colon_split_and_rearms(
+    real_redis_client,
+):
+    # Arrange
+    # A union member whose Key[str] pk itself contains a colon ("tenant:42"), so
+    # its full key is "CascadeColonPkMember:tenant:42". Server-side resolution
+    # splits on the FIRST colon (string.match '^([^:]+):' mirrors the Python
+    # key.setter split(':', maxsplit=1)), so the resolved prefix is the CLASS
+    # NAME -- never a pk segment. The member must still be matched as a candidate
+    # and re-armed (RESEARCH Pitfall 2).
+    member = await CascadeColonPkMember(member_id="tenant:42").asave()
+    assert member.key == "CascadeColonPkMember:tenant:42"
+    owner = await CascadeColonPkOwner(ref=member.key).asave()
+    for key in (owner.key, member.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    assert await real_redis_client.ttl(member.key) > 0
+    assert result[2] == 0

--- a/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_multi_class_apply.py
@@ -4,8 +4,15 @@ from rapyer.result import CascadeResult
 from tests.integration.foreign_keys.conftest import apply_cascade
 from tests.models.cascade_types import (
     CASCADE_FIXTURE_TTL_SECONDS,
+    CascadeAuthor,
+    CascadeChainNode,
     CascadeColonPkMember,
     CascadeColonPkOwner,
+    CascadeMultiClassDiamondLeaf,
+    CascadeMultiClassDiamondMemberA,
+    CascadeMultiClassDiamondMemberB,
+    CascadeMultiClassDiamondRoot,
+    CascadeUnionDepthRoot,
     CascadeUnionDictOwner,
     CascadeUnionListOwner,
     CascadeUnionMemberA,
@@ -227,3 +234,148 @@ async def test_colon_bearing_pk_member_resolves_via_first_colon_split_and_rearms
     # Assert
     assert await real_redis_client.ttl(member.key) > 0
     assert result[2] == 0
+
+
+# --- Task 2: cycle-safe mixed-class diamond over a shared leaf (CMCT-08) ---
+
+
+@pytest.mark.asyncio
+async def test_mixed_class_diamond_shared_leaf_rearmed_via_two_candidate_classes(
+    real_redis_client,
+):
+    # Arrange
+    # A single shared leaf FK'd by TWO DIFFERENT candidate classes
+    # (CascadeMultiClassDiamondMemberA and ...MemberB). The diamond root's scalar
+    # edge is a union over both member classes; whichever candidate it resolves
+    # to, the cascade continues on to the SAME shared leaf. Two roots -- one
+    # resolving to member-A, one to member-B -- exercise the shared leaf via two
+    # DISTINCT candidate-class paths (the CascadeMultiClassDiamondRoot scalar-union
+    # fixture only carries one candidate per instance, so the two candidate-class
+    # paths are driven by two root instances, mirroring the accepted
+    # test_shared_child_via_two_independent_roots pattern). Within each walk the
+    # shared leaf is re-armed exactly once at the best budget via the visited
+    # best-budget map (the map is unchanged by D-01 -- cycle/diamond dedup is
+    # inherited, already proven by test_diamond_shared_child / test_max_budget_wins),
+    # and every diamond node is re-armed to its OWN class Meta.ttl with no
+    # double-refresh crash.
+    leaf = await CascadeMultiClassDiamondLeaf(name="shared").asave()
+    member_a = await CascadeMultiClassDiamondMemberA(leaf=leaf.key).asave()
+    member_b = await CascadeMultiClassDiamondMemberB(leaf=leaf.key).asave()
+    root_a = await CascadeMultiClassDiamondRoot(member=member_a.key).asave()
+    root_b = await CascadeMultiClassDiamondRoot(member=member_b.key).asave()
+    for key in (root_a.key, root_b.key, member_a.key, member_b.key, leaf.key):
+        await real_redis_client.persist(key)
+
+    # Act / Assert -- candidate-class path A: root -> member A -> shared leaf.
+    result_a = await apply_cascade(real_redis_client, root_a)
+    for key in (root_a.key, member_a.key, leaf.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result_a[2] == 0
+
+    # Re-arm the leaf's dangling state, then candidate-class path B:
+    # root -> member B -> the SAME shared leaf. The leaf re-arms via either
+    # candidate-class path, never a collision or double-refresh error.
+    await real_redis_client.persist(leaf.key)
+    result_b = await apply_cascade(real_redis_client, root_b)
+    for key in (root_b.key, member_b.key, leaf.key):
+        assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
+    assert result_b[2] == 0
+
+
+# --- Task 2: per-subtree depth budget truncates THROUGH a resolved-class edge ---
+
+
+@pytest.mark.asyncio
+async def test_depth_budget_truncates_through_a_resolved_class_union_edge(
+    real_redis_client,
+):
+    # Arrange
+    # A 3-node blanket-decrementing CascadeChainNode chain (c1 -> c2 -> c3),
+    # entered THROUGH CascadeUnionDepthRoot's union edge (candidates:
+    # CascadeChainNode | CascadeUnionMemberB) capped at depth=1. entry resolves
+    # c1's class from its "CascadeChainNode:" prefix among the edge's candidates
+    # and carries the reset depth=1 budget into c1's subtree:
+    #   c1 at budget 1  -> re-armed
+    #   c2 at budget 0  -> re-armed (the one in-budget blanket hop)
+    #   c3 at budget -1 -> truncated, NOT re-armed
+    # The budget argument and the visited best-budget map pass through push_child
+    # UNCHANGED (D-01 resolves only the CHILD's class), so the budget arithmetic is
+    # inherited from the single-target path already proven by
+    # test_cascade_depth_and_gate.py::test_independent_sibling_depth_budgets. This
+    # test adds the DIRECT multi-class leg so CMCT-08's depth-budget clause is
+    # traceable, not merely indirect.
+    c3 = await CascadeChainNode(name="c3").asave()
+    c2 = await CascadeChainNode(name="c2", next=c3.key).asave()
+    c1 = await CascadeChainNode(name="c1", next=c2.key).asave()
+    root = await CascadeUnionDepthRoot(entry=c1.key).asave()
+    all_keys = (root.key, c1.key, c2.key, c3.key)
+    for key in all_keys:
+        await real_redis_client.persist(key)
+
+    # Act
+    await apply_cascade(real_redis_client, root)
+
+    # Assert
+    refreshed = {key for key in all_keys if await real_redis_client.ttl(key) > 0}
+    assert refreshed == {root.key, c1.key, c2.key}
+    assert await real_redis_client.ttl(c3.key) in (-1, -2)
+
+
+# --- Task 2: dead-end contracts -- counted non-candidate vs uncounted corrupt ---
+
+
+@pytest.mark.asyncio
+async def test_non_candidate_reach_is_skipped_and_tallied_as_class_drift(
+    real_redis_client,
+):
+    # Arrange
+    # A union owner's ref points at a saved CascadeAuthor key. CascadeAuthor is a
+    # registered, plan-present model but is NOT among CascadeUnionOwner.ref's
+    # candidates ({CascadeUnionMemberA, CascadeUnionMemberB}). The reach resolves
+    # to a valid-but-non-candidate class: it MUST be skipped (no TTL applied) AND
+    # tallied in the FCALL's third return element (mismatched_class), giving
+    # operators a class-drift signal (D-03, CMCT-10).
+    #
+    # The tally is asserted at REACH time (at-least-once, NOT deduped via the
+    # visited map): per the LOCKED D-03 choice, the requirement is observability
+    # of drift, not exact-once accounting -- a non-candidate reached via two paths
+    # may count more than once, and that is acceptable.
+    author = await CascadeAuthor(name="drift").asave()
+    owner = await CascadeUnionOwner(ref=author.key).asave()
+    for key in (owner.key, author.key):
+        await real_redis_client.persist(key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    # No misapplied TTL on the non-candidate key ...
+    assert await real_redis_client.ttl(author.key) in (-1, -2)
+    # ... and the drift is observed (mismatched_class incremented).
+    assert result[2] == 1
+    # The root itself still re-arms -- the non-candidate reach is a safe dead-end,
+    # never an aborted FCALL (T-02-07 mitigation).
+    assert await real_redis_client.ttl(owner.key) > 0
+
+
+@pytest.mark.asyncio
+async def test_corrupt_no_colon_reach_is_a_silent_uncounted_dead_end(
+    real_redis_client,
+):
+    # Arrange
+    # A union owner's ref holds a corrupt, colon-less value. string.match on the
+    # first-colon pattern yields nil, so the reach is the EXISTING silent dead-end
+    # (skip, no crash) and is NOT tallied as class drift -- only a parsed-but-non-
+    # candidate PREFIX is counted (D-03, CMCT-10). This distinguishes a corrupt
+    # reach (uncounted) from a class-drift reach (counted, previous test).
+    owner = await CascadeUnionOwner(ref="corrupt-no-colon-value").asave()
+    await real_redis_client.persist(owner.key)
+
+    # Act
+    result = await apply_cascade(real_redis_client, owner)
+
+    # Assert
+    # No class-drift tally for a corrupt (colon-less) reach ...
+    assert result[2] == 0
+    # ... and the FCALL completes, re-arming the root (safe dead-end, T-02-07).
+    assert await real_redis_client.ttl(owner.key) > 0

--- a/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
+++ b/tests/integration/foreign_keys/test_cascade_sf_held_ref_apply.py
@@ -80,8 +80,9 @@ async def test_set_ref_dangling_member_reuses_existing_dangling_count(
     # Act
     result = await apply_cascade(real_redis_client, parent)
 
-    # Assert (no separate SF-dangling counter -- reuses the existing dangling shape)
-    assert result == [1, 0]
+    # Assert (no separate SF-dangling counter -- reuses the existing dangling shape;
+    # third element is the D-03 mismatched_class counter, 0 for a single-target reach)
+    assert result == [1, 0, 0]
     for key in (parent.key, author.key):
         assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
 
@@ -211,4 +212,4 @@ async def test_sf_only_dual_edge_diamond_shared_child_refreshed_exactly_once(
     # Assert
     for key in (root.key, child.key):
         assert 0 < await real_redis_client.ttl(key) <= CASCADE_FIXTURE_TTL_SECONDS
-    assert result == [0, 0]
+    assert result == [0, 0, 0]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -5,6 +5,7 @@ from pydantic import Field
 from rapyer.base import AtomicRedisModel
 from rapyer.cascade import CascadeTTL
 from rapyer.config import RedisConfig
+from rapyer.fields.key import Key
 from rapyer.types.foreign_key import Reference
 from rapyer.types.priority_queue import RedisPriorityQueue
 from rapyer.types.redis_set import RedisSet
@@ -559,6 +560,128 @@ class CascadePolyDedupOwner(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
 
 
+# --- Multi-candidate FK fixtures across every remaining FK shape (Wave 0) ---
+#
+# The Phase-1 union fixtures above cover only the SCALAR union shape
+# (CascadeUnionOwner). These owners extend the same union target
+# (CascadeUnionMemberA | CascadeUnionMemberB) across the collection and
+# special-field shapes so build_cascade_plan enumerates BOTH members as
+# candidates on every FK shape, not just the scalar one. Members are REUSED,
+# not reinvented.
+
+
+class CascadeUnionListOwner(AtomicRedisModel):
+    """Collection-of-union shape: list[Reference[A | B]] carrying the marker on
+    the collection itself (mirrors CascadeBookCollection, union target)."""
+
+    refs: Annotated[
+        list[Reference[CascadeUnionMemberA | CascadeUnionMemberB]], CascadeTTL()
+    ] = Field(default_factory=list)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeUnionDictOwner(AtomicRedisModel):
+    """Collection-of-union shape: dict[str, Reference[A | B]] carrying the
+    marker on the collection itself (mirrors CascadeDictCollectionRoot)."""
+
+    refs: Annotated[
+        dict[str, Reference[CascadeUnionMemberA | CascadeUnionMemberB]], CascadeTTL()
+    ] = Field(default_factory=dict)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeUnionSetOwner(AtomicRedisModel):
+    """SF-held-union shape: RedisSet[Reference[A | B]] carrying the marker on
+    the special field (mirrors CascadeSetRefParent, union target)."""
+
+    refs: Annotated[
+        RedisSet[Reference[CascadeUnionMemberA | CascadeUnionMemberB]], CascadeTTL()
+    ] = Field(default_factory=RedisSet)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeUnionPQOwner(AtomicRedisModel):
+    """SF-held-union shape: RedisPriorityQueue[Reference[A | B]] carrying the
+    marker on the special field (mirrors CascadePQRefParent, union target)."""
+
+    queue: Annotated[
+        RedisPriorityQueue[Reference[CascadeUnionMemberA | CascadeUnionMemberB]],
+        CascadeTTL(),
+    ] = Field(default_factory=RedisPriorityQueue)
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+# --- Mixed-class diamond: two candidate classes share a single leaf ---
+
+
+class CascadeMultiClassDiamondLeaf(AtomicRedisModel):
+    """Plain ttl-bearing leaf FK'd by BOTH diamond members. A real cascade
+    reaches this single shared leaf via two distinct candidate-class paths."""
+
+    name: str = "multi_class_diamond_leaf"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeMultiClassDiamondMemberA(AtomicRedisModel):
+    """Diamond member A — carries a scalar FK to the shared leaf."""
+
+    leaf: Annotated[Reference[CascadeMultiClassDiamondLeaf], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeMultiClassDiamondMemberB(AtomicRedisModel):
+    """Diamond member B (a DIFFERENT class than A) — carries a scalar FK to the
+    SAME shared leaf, so the leaf is reachable via two candidate classes."""
+
+    leaf: Annotated[Reference[CascadeMultiClassDiamondLeaf], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeMultiClassDiamondRoot(AtomicRedisModel):
+    """Union-FK root whose scalar edge lists both diamond members as candidates.
+    Whichever member it resolves to, the cascade continues on to the single
+    shared leaf — a mixed-class diamond over a shared child (CMCT-08)."""
+
+    member: Annotated[
+        Reference[CascadeMultiClassDiamondMemberA | CascadeMultiClassDiamondMemberB],
+        CascadeTTL(),
+    ]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+# --- Colon-bearing Key[...] pk union member (Pitfall 2 lock) ---
+
+
+class CascadeColonPkMember(AtomicRedisModel):
+    """Union member with a Key[str]-annotated pk so a saved instance can carry a
+    colon-bearing pk. Locks the first-colon {class}:{pk} split against a pk that
+    itself contains a colon (RESEARCH Pitfall 2)."""
+
+    member_id: Key[str]
+    name: str = "colon_pk_member"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeColonPkOwner(AtomicRedisModel):
+    """Owns a scalar union FK whose candidates include the colon-pk member, so
+    reached-key class resolution can be locked against a colon-bearing pk."""
+
+    ref: Annotated[
+        Reference[CascadeColonPkMember | CascadeUnionMemberA], CascadeTTL()
+    ]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,
@@ -601,4 +724,14 @@ ALL_CASCADE_MODELS = [
     CascadeUnionMemberA,
     CascadeUnionMemberB,
     CascadeUnionOwner,
+    CascadeUnionListOwner,
+    CascadeUnionDictOwner,
+    CascadeUnionSetOwner,
+    CascadeUnionPQOwner,
+    CascadeMultiClassDiamondLeaf,
+    CascadeMultiClassDiamondMemberA,
+    CascadeMultiClassDiamondMemberB,
+    CascadeMultiClassDiamondRoot,
+    CascadeColonPkMember,
+    CascadeColonPkOwner,
 ]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -682,6 +682,28 @@ class CascadeColonPkOwner(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
 
 
+# --- Union-edge depth-budget fixture (CMCT-08 depth clause, Plan 04) ---
+
+
+class CascadeUnionDepthRoot(AtomicRedisModel):
+    """Enters a chain THROUGH a resolved-class (union) edge under a per-subtree
+    depth cap. The single scalar ``entry`` edge is a UNION whose two candidates
+    are the EXISTING blanket-decrementing ``CascadeChainNode`` and the EXISTING
+    ``CascadeUnionMemberB`` leaf (neither reinvented, neither modified). Capped at
+    ``depth=1``: when ``entry`` resolves the reached key's class from its
+    ``CascadeChainNode:`` prefix, the reset depth=1 budget is carried into that
+    child's subtree, so the chain truncates one hop in -- proving the per-subtree
+    depth budget is honored THROUGH a multi-class edge, not merely on single-target
+    chains (CMCT-08 depth-budget clause, proven DIRECTLY not just via the diamond).
+    """
+
+    entry: Annotated[
+        Reference[CascadeChainNode | CascadeUnionMemberB], CascadeTTL(depth=1)
+    ]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,
@@ -734,4 +756,5 @@ ALL_CASCADE_MODELS = [
     CascadeMultiClassDiamondRoot,
     CascadeColonPkMember,
     CascadeColonPkOwner,
+    CascadeUnionDepthRoot,
 ]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -598,4 +598,7 @@ ALL_CASCADE_MODELS = [
     CascadeMixedEdgeSharedChildRoot,
     CascadeSfDiamondChild,
     CascadeSfDiamondRoot,
+    CascadeUnionMemberA,
+    CascadeUnionMemberB,
+    CascadeUnionOwner,
 ]

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -483,6 +483,39 @@ class CascadeSfDiamondRoot(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
 
 
+# --- Multi-candidate FK fixtures (union targets) ---
+
+
+class CascadeUnionMemberA(AtomicRedisModel):
+    """Concrete union member A — a plain ttl-bearing leaf."""
+
+    name: str = "union_member_a"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeUnionMemberB(AtomicRedisModel):
+    """Concrete union member B — a plain ttl-bearing leaf."""
+
+    name: str = "union_member_b"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadeUnionOwner(AtomicRedisModel):
+    """Owns a scalar FK whose target is a union of two models.
+
+    The whole point of the phase: the edge must list BOTH members as
+    candidate targets rather than crashing on ``UnionType.__name__``.
+    """
+
+    ref: Annotated[
+        Reference[CascadeUnionMemberA | CascadeUnionMemberB], CascadeTTL()
+    ]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,

--- a/tests/models/cascade_types.py
+++ b/tests/models/cascade_types.py
@@ -516,6 +516,49 @@ class CascadeUnionOwner(AtomicRedisModel):
     Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
 
 
+# --- Multi-candidate FK fixtures (polymorphic base + registered subclasses) ---
+
+
+class CascadePolyBase(AtomicRedisModel):
+    """Registered polymorphic base — a candidate in its own right (Decision #3:
+    included because it is a registered, ttl-bearing, saveable model)."""
+
+    name: str = "poly_base"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePolySub1(CascadePolyBase):
+    """First registered subclass of CascadePolyBase."""
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePolySub2(CascadePolyBase):
+    """Second registered subclass of CascadePolyBase."""
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePolyOwner(AtomicRedisModel):
+    """Owns a scalar FK to a polymorphic base with registered subclasses."""
+
+    ref: Annotated[Reference[CascadePolyBase], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
+class CascadePolyDedupOwner(AtomicRedisModel):
+    """Union whose members overlap: CascadePolySub1 is both a listed union
+    member and a subclass of CascadePolyBase, so it must appear exactly once."""
+
+    ref: Annotated[
+        Reference[CascadePolyBase | CascadePolySub1], CascadeTTL()
+    ]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=CASCADE_FIXTURE_TTL_SECONDS)
+
+
 # Full cascade-model set shared by unit and integration cascade fixtures.
 ALL_CASCADE_MODELS = [
     CascadeAuthor,

--- a/tests/unit/cascade/test_aset_ttl_cascade_flag.py
+++ b/tests/unit/cascade/test_aset_ttl_cascade_flag.py
@@ -29,7 +29,7 @@ async def test_aset_ttl_default_cascade_false_runs_the_script_with_cascade_argv_
     # the default cascade=False -- only the trailing ARGV cascade flag
     # differs, never a separate per-key EXPIRE branch.
     mock_pipe, mock_run_fcall = fcall_pipeline_spy
-    mock_pipe.execute = AsyncMock(return_value=[[0, 0]])
+    mock_pipe.execute = AsyncMock(return_value=[[0, 0, 0]])
     root = CascadeChainRoot(head="CascadeChainNode:fake")
 
     with patch("rapyer.base._context_pipe") as mock_context_pipe:
@@ -59,7 +59,7 @@ async def test_aset_ttl_cascade_true_runs_the_script_with_cascade_argv_one(
 ):
     # Arrange
     mock_pipe, mock_run_fcall = fcall_pipeline_spy
-    mock_pipe.execute = AsyncMock(return_value=[[0, 0]])
+    mock_pipe.execute = AsyncMock(return_value=[[0, 0, 0]])
     root = CascadeChainRoot(head="CascadeChainNode:fake")
 
     with patch("rapyer.base._context_pipe") as mock_context_pipe:
@@ -78,7 +78,9 @@ async def test_aset_ttl_cascade_true_runs_the_script_with_cascade_argv_one(
         TTL_SECONDS,
         1,
     )
-    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
 
 
 @pytest.mark.asyncio
@@ -89,7 +91,7 @@ async def test_aset_ttl_cascade_standalone_owns_execution_and_returns_cascade_re
     # Standalone call (no outer pipeline): enqueues run_sha, awaits
     # pipe.execute() itself, and decodes the two-element result.
     mock_pipe, mock_run_fcall = fcall_pipeline_spy
-    mock_pipe.execute = AsyncMock(return_value=[[1, 2]])
+    mock_pipe.execute = AsyncMock(return_value=[[1, 2, 0]])
     root = CascadeChainRoot(head="CascadeChainNode:fake")
 
     with patch("rapyer.base._context_pipe") as mock_context_pipe:
@@ -109,7 +111,9 @@ async def test_aset_ttl_cascade_standalone_owns_execution_and_returns_cascade_re
         1,
     )
     mock_pipe.execute.assert_awaited_once()
-    assert result == CascadeResult(dangling_children=1, dangling_special=2)
+    assert result == CascadeResult(
+        dangling_children=1, dangling_special=2, mismatched_class=0
+    )
 
 
 @pytest.mark.asyncio
@@ -122,7 +126,7 @@ async def test_aset_ttl_cascade_standalone_awaits_pipe_execute_directly(
     # NOSCRIPT (tracked as a follow-up, see NOSCRIPT-ISSUE.md). It must still
     # capture the awaited results[-1] for the CascadeResult.
     mock_pipe, _ = fcall_pipeline_spy
-    mock_pipe.execute = AsyncMock(return_value=[[3, 4]])
+    mock_pipe.execute = AsyncMock(return_value=[[3, 4, 0]])
     root = CascadeChainRoot(head="CascadeChainNode:fake")
 
     with patch("rapyer.base._context_pipe") as mock_context_pipe:
@@ -132,7 +136,9 @@ async def test_aset_ttl_cascade_standalone_awaits_pipe_execute_directly(
 
     # Assert
     mock_pipe.execute.assert_awaited_once()
-    assert result == CascadeResult(dangling_children=3, dangling_special=4)
+    assert result == CascadeResult(
+        dangling_children=3, dangling_special=4, mismatched_class=0
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cascade/test_cascade_action_boundary.py
+++ b/tests/unit/cascade/test_cascade_action_boundary.py
@@ -49,7 +49,9 @@ async def test_aset_ttl_cascade_true_on_fakeredis_refreshes_only_root_no_travers
     result = await parent.aset_ttl(ROOT_TTL_SECONDS, cascade=True)
 
     # Assert
-    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
     assert await fake_redis_client.ttl(parent.key) > 0
     assert await fake_redis_client.ttl(child.key) == -1
 

--- a/tests/unit/cascade/test_cascade_key_initials_guard.py
+++ b/tests/unit/cascade/test_cascade_key_initials_guard.py
@@ -1,0 +1,112 @@
+"""Unit tests for validate_cascade_key_initials (D-02 fail-fast guard).
+
+These tests drive the guard DIRECTLY on locally-constructed model lists — they
+never route through the global init_rapyer() / REDIS_MODELS registry. Every
+local fixture below is declared with ``init_with_rapyer=False`` so it stays out
+of REDIS_MODELS and cannot poison the global model set for other tests.
+"""
+
+from typing import Annotated, ClassVar
+
+import pytest
+
+from rapyer.base import AtomicRedisModel
+from rapyer.cascade import CascadeTTL
+from rapyer.cascade.planner import build_cascade_plan, validate_cascade_key_initials
+from rapyer.config import RedisConfig
+from rapyer.errors import CascadeKeyInitialsError
+from rapyer.types.foreign_key import Reference
+
+_GUARD_TTL = 3600
+_OVERRIDDEN_INITIALS = "ZZ"
+
+
+class GuardConformingTarget(AtomicRedisModel):
+    """A reached target that keeps the default class_key_initials() == __name__."""
+
+    name: str = "conforming_target"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=_GUARD_TTL, init_with_rapyer=False)
+
+
+class GuardConformingOwner(AtomicRedisModel):
+    """A cascade root pointing at a conforming target; both default initials."""
+
+    ref: Annotated[Reference[GuardConformingTarget], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=_GUARD_TTL, init_with_rapyer=False)
+
+
+class GuardBadReachedTarget(AtomicRedisModel):
+    """A NON-root reached target overriding class_key_initials() to a constant
+    != __name__ — the exact silent-mis-resolve seam D-02 guards. It is never a
+    cascade root (it owns no cascade edge); it participates only as the target
+    reached via GuardBadReachedOwner's edge, locking the participant-scope."""
+
+    name: str = "bad_reached_target"
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=_GUARD_TTL, init_with_rapyer=False)
+
+    @classmethod
+    def class_key_initials(cls):
+        return _OVERRIDDEN_INITIALS
+
+
+class GuardBadReachedOwner(AtomicRedisModel):
+    """A conforming root whose edge reaches the mis-keyed GuardBadReachedTarget."""
+
+    ref: Annotated[Reference[GuardBadReachedTarget], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=_GUARD_TTL, init_with_rapyer=False)
+
+
+class GuardBadRoot(AtomicRedisModel):
+    """A cascade ROOT that itself overrides class_key_initials() != __name__."""
+
+    ref: Annotated[Reference[GuardConformingTarget], CascadeTTL()]
+
+    Meta: ClassVar[RedisConfig] = RedisConfig(ttl=_GUARD_TTL, init_with_rapyer=False)
+
+    @classmethod
+    def class_key_initials(cls):
+        return _OVERRIDDEN_INITIALS
+
+
+def test_conforming_participant_plan_raises_nothing():
+    # Arrange
+    models = [GuardConformingOwner, GuardConformingTarget]
+
+    # Act / Assert — every participant keeps class_key_initials() == __name__.
+    validate_cascade_key_initials(models)
+
+
+def test_override_on_reached_non_root_candidate_raises():
+    # Arrange — the override lives on a target reached ONLY via an edge (non-root).
+    models = [GuardBadReachedOwner, GuardBadReachedTarget]
+
+    # Assert the plan really makes GuardBadReachedTarget a non-root participant.
+    plan = build_cascade_plan(models)
+    assert plan["GuardBadReachedTarget"].fks == []
+    assert plan["GuardBadReachedOwner"].fks, "owner must own the reaching edge"
+
+    # Act / Assert
+    with pytest.raises(CascadeKeyInitialsError) as exc_info:
+        validate_cascade_key_initials(models)
+
+    error = exc_info.value
+    assert error.model_name == "GuardBadReachedTarget"
+    message = str(error)
+    assert "GuardBadReachedTarget" in message
+    assert _OVERRIDDEN_INITIALS in message
+
+
+def test_override_on_root_participant_raises():
+    # Arrange — a cascade root that mis-keys its own key prefix.
+    models = [GuardBadRoot, GuardConformingTarget]
+
+    # Act / Assert
+    with pytest.raises(CascadeKeyInitialsError) as exc_info:
+        validate_cascade_key_initials(models)
+
+    assert exc_info.value.model_name == "GuardBadRoot"
+    assert _OVERRIDDEN_INITIALS in str(exc_info.value)

--- a/tests/unit/cascade/test_cascade_multi_candidate_plan.py
+++ b/tests/unit/cascade/test_cascade_multi_candidate_plan.py
@@ -1,0 +1,40 @@
+import pytest
+
+from rapyer.cascade.planner import build_cascade_plan
+from tests.models.cascade_types import (
+    CascadeBlanketLeaf,
+    CascadeBlanketRoot,
+    CascadeUnionMemberA,
+    CascadeUnionMemberB,
+    CascadeUnionOwner,
+)
+
+pytestmark = pytest.mark.usefixtures("setup_fake_redis_for_cascade_models")
+
+
+def test_scalar_union_fk_lists_every_candidate():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeUnionOwner, CascadeUnionMemberA, CascadeUnionMemberB]
+    )
+
+    # Assert
+    edges = plan["CascadeUnionOwner"].fks
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.path == "$.ref"
+    # Both union members are candidates, in declaration order; target is the first.
+    assert edge.candidates == ["CascadeUnionMemberA", "CascadeUnionMemberB"]
+    assert edge.target == "CascadeUnionMemberA"
+
+
+def test_single_target_edge_is_unchanged_with_none_candidates():
+    # Act
+    plan = build_cascade_plan([CascadeBlanketRoot, CascadeBlanketLeaf])
+
+    # Assert
+    # A pre-existing single-target edge keeps its scalar target and carries no
+    # candidates list (byte-identity preserved: candidates=None is dropped).
+    edge = plan["CascadeBlanketRoot"].fks[0]
+    assert edge.target == "CascadeBlanketLeaf"
+    assert edge.candidates is None

--- a/tests/unit/cascade/test_cascade_multi_candidate_plan.py
+++ b/tests/unit/cascade/test_cascade_multi_candidate_plan.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rapyer.cascade.planner import build_cascade_plan
+from tests.unit.cascade.conftest import CASCADE_PLANNER_MODELS
 from tests.models.cascade_types import (
     CascadeBlanketLeaf,
     CascadeBlanketRoot,
@@ -108,3 +109,14 @@ def test_base_with_no_registered_subclasses_degrades_to_single_target():
     edge = plan["CascadePolyOwner"].fks[0]
     assert edge.target == "CascadePolyBase"
     assert edge.candidates is None
+
+
+def test_no_preexisting_single_target_model_is_silently_expanded():
+    # Assert (Assumption A2)
+    # Every model that shipped before this phase is single-target; none of them
+    # has registered subclasses or a union FK, so the subclass-expansion rule
+    # must leave every pre-existing edge with candidates=None (byte-identity).
+    plan = build_cascade_plan(CASCADE_PLANNER_MODELS)
+    for class_name, entry in plan.items():
+        for edge in entry.fks:
+            assert edge.candidates is None, (class_name, edge.path)

--- a/tests/unit/cascade/test_cascade_multi_candidate_plan.py
+++ b/tests/unit/cascade/test_cascade_multi_candidate_plan.py
@@ -5,14 +5,24 @@ from tests.unit.cascade.conftest import CASCADE_PLANNER_MODELS
 from tests.models.cascade_types import (
     CascadeBlanketLeaf,
     CascadeBlanketRoot,
+    CascadeColonPkMember,
+    CascadeColonPkOwner,
+    CascadeMultiClassDiamondLeaf,
+    CascadeMultiClassDiamondMemberA,
+    CascadeMultiClassDiamondMemberB,
+    CascadeMultiClassDiamondRoot,
     CascadePolyBase,
     CascadePolyDedupOwner,
     CascadePolyOwner,
     CascadePolySub1,
     CascadePolySub2,
+    CascadeUnionDictOwner,
+    CascadeUnionListOwner,
     CascadeUnionMemberA,
     CascadeUnionMemberB,
     CascadeUnionOwner,
+    CascadeUnionPQOwner,
+    CascadeUnionSetOwner,
 )
 
 pytestmark = pytest.mark.usefixtures("setup_fake_redis_for_cascade_models")
@@ -120,3 +130,99 @@ def test_no_preexisting_single_target_model_is_silently_expanded():
     for class_name, entry in plan.items():
         for edge in entry.fks:
             assert edge.candidates is None, (class_name, edge.path)
+
+
+# --- Candidate enumeration extends across every FK shape (Wave 0, CMCT-07) ---
+#
+# These prove the Phase-1 edge.candidates enumeration already extends across the
+# collection (list/dict) and special-field (RedisSet/RedisPriorityQueue) shapes,
+# not just the scalar union. Set-equality comparisons make the assertion
+# order-independent (CMCT-07 ordering-independence at the plan level) and give
+# the Plan-04 integration proofs a static precondition. Pure introspection over
+# build_cascade_plan — fakeredis-safe, no Redis I/O.
+
+_UNION_MEMBERS = {"CascadeUnionMemberA", "CascadeUnionMemberB"}
+
+
+def test_list_of_union_fk_enumerates_both_members():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeUnionListOwner, CascadeUnionMemberA, CascadeUnionMemberB]
+    )
+
+    # Assert
+    edge = plan["CascadeUnionListOwner"].fks[0]
+    assert set(edge.candidates) == _UNION_MEMBERS
+
+
+def test_dict_of_union_fk_enumerates_both_members():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeUnionDictOwner, CascadeUnionMemberA, CascadeUnionMemberB]
+    )
+
+    # Assert
+    edge = plan["CascadeUnionDictOwner"].fks[0]
+    assert set(edge.candidates) == _UNION_MEMBERS
+
+
+def test_redis_set_of_union_fk_enumerates_both_members():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeUnionSetOwner, CascadeUnionMemberA, CascadeUnionMemberB]
+    )
+
+    # Assert
+    edge = plan["CascadeUnionSetOwner"].fks[0]
+    assert set(edge.candidates) == _UNION_MEMBERS
+
+
+def test_priority_queue_of_union_fk_enumerates_both_members():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeUnionPQOwner, CascadeUnionMemberA, CascadeUnionMemberB]
+    )
+
+    # Assert
+    edge = plan["CascadeUnionPQOwner"].fks[0]
+    assert set(edge.candidates) == _UNION_MEMBERS
+
+
+def test_mixed_class_diamond_root_lists_both_member_classes():
+    # Act
+    plan = build_cascade_plan(
+        [
+            CascadeMultiClassDiamondRoot,
+            CascadeMultiClassDiamondMemberA,
+            CascadeMultiClassDiamondMemberB,
+            CascadeMultiClassDiamondLeaf,
+        ]
+    )
+
+    # Assert
+    # The union-FK root enumerates both diamond member classes as candidates;
+    # each member independently FKs the SAME shared leaf (the mixed-class
+    # diamond that Plan 04 drives on real Redis).
+    edge = plan["CascadeMultiClassDiamondRoot"].fks[0]
+    assert set(edge.candidates) == {
+        "CascadeMultiClassDiamondMemberA",
+        "CascadeMultiClassDiamondMemberB",
+    }
+    # Both members reach the identical leaf class.
+    member_a_edge = plan["CascadeMultiClassDiamondMemberA"].fks[0]
+    member_b_edge = plan["CascadeMultiClassDiamondMemberB"].fks[0]
+    assert member_a_edge.target == "CascadeMultiClassDiamondLeaf"
+    assert member_b_edge.target == "CascadeMultiClassDiamondLeaf"
+
+
+def test_colon_pk_union_owner_enumerates_both_candidates():
+    # Act
+    plan = build_cascade_plan(
+        [CascadeColonPkOwner, CascadeColonPkMember, CascadeUnionMemberA]
+    )
+
+    # Assert
+    # The colon-pk member is a first-class candidate alongside the plain-pk
+    # member, so reached-key resolution can be locked against a colon-bearing pk.
+    edge = plan["CascadeColonPkOwner"].fks[0]
+    assert set(edge.candidates) == {"CascadeColonPkMember", "CascadeUnionMemberA"}

--- a/tests/unit/cascade/test_cascade_multi_candidate_plan.py
+++ b/tests/unit/cascade/test_cascade_multi_candidate_plan.py
@@ -4,6 +4,11 @@ from rapyer.cascade.planner import build_cascade_plan
 from tests.models.cascade_types import (
     CascadeBlanketLeaf,
     CascadeBlanketRoot,
+    CascadePolyBase,
+    CascadePolyDedupOwner,
+    CascadePolyOwner,
+    CascadePolySub1,
+    CascadePolySub2,
     CascadeUnionMemberA,
     CascadeUnionMemberB,
     CascadeUnionOwner,
@@ -37,4 +42,69 @@ def test_single_target_edge_is_unchanged_with_none_candidates():
     # candidates list (byte-identity preserved: candidates=None is dropped).
     edge = plan["CascadeBlanketRoot"].fks[0]
     assert edge.target == "CascadeBlanketLeaf"
+    assert edge.candidates is None
+
+
+def test_polymorphic_base_fk_enumerates_base_and_all_subclasses():
+    # Act
+    plan = build_cascade_plan(
+        [CascadePolyOwner, CascadePolyBase, CascadePolySub1, CascadePolySub2]
+    )
+
+    # Assert
+    # Base included (Decision #3: registered, ttl-bearing) plus every subclass
+    # enumerated from the threaded models list — three candidates, not one.
+    edge = plan["CascadePolyOwner"].fks[0]
+    assert set(edge.candidates) == {
+        "CascadePolyBase",
+        "CascadePolySub1",
+        "CascadePolySub2",
+    }
+    assert len(edge.candidates) == 3
+
+
+def test_candidate_ordering_is_declaration_order_with_target_first():
+    # Act
+    plan = build_cascade_plan(
+        [CascadePolyOwner, CascadePolyBase, CascadePolySub1, CascadePolySub2]
+    )
+
+    # Assert
+    edge = plan["CascadePolyOwner"].fks[0]
+    assert edge.candidates == [
+        "CascadePolyBase",
+        "CascadePolySub1",
+        "CascadePolySub2",
+    ]
+    assert edge.target == edge.candidates[0]
+
+
+def test_candidates_are_deduplicated_when_reachable_via_two_paths():
+    # Act
+    plan = build_cascade_plan(
+        [CascadePolyDedupOwner, CascadePolyBase, CascadePolySub1, CascadePolySub2]
+    )
+
+    # Assert
+    # CascadePolySub1 is both a listed union member and a subclass of the base;
+    # it must appear exactly once, order-preserving.
+    edge = plan["CascadePolyDedupOwner"].fks[0]
+    assert edge.candidates == [
+        "CascadePolyBase",
+        "CascadePolySub1",
+        "CascadePolySub2",
+    ]
+    assert edge.candidates.count("CascadePolySub1") == 1
+
+
+def test_base_with_no_registered_subclasses_degrades_to_single_target():
+    # Act
+    # Option B threading: subclasses absent from the passed models list are not
+    # enumerated, so a base with no reachable subclasses degrades to a single
+    # target (candidates dropped, byte-identical).
+    plan = build_cascade_plan([CascadePolyOwner, CascadePolyBase])
+
+    # Assert
+    edge = plan["CascadePolyOwner"].fks[0]
+    assert edge.target == "CascadePolyBase"
     assert edge.candidates is None

--- a/tests/unit/cascade/test_cascade_multi_class_fakeredis_fallback.py
+++ b/tests/unit/cascade/test_cascade_multi_class_fakeredis_fallback.py
@@ -1,0 +1,143 @@
+"""fakeredis no-op divergence proof for a UNION-FK owner (CMCT-11 fallback leg).
+
+The cascade Redis Function NEVER runs on fakeredis (no Redis Functions there);
+``aset_ttl(cascade=True)`` takes the native-EXPIRE fast path over the ROOT's own
+keys only -- no traversal. These tests pin exactly that documented divergence for
+a multi-class (union) FK owner: the root's own keys (its main document key and/or
+its own SF-container key) are re-armed, but a REACHED union member is NOT (the
+Function that would resolve its {class}:{pk} prefix and re-arm it never executes
+here). The returned ``CascadeResult`` is the zero-drift fast-path value
+``mismatched_class=0`` with zero danglings -- the native fast path produces no
+counters at all, including zero class drift.
+
+This is the fallback leg ONLY. It deliberately asserts NO traversal: the real
+multi-class reach proof lives in the real-Redis integration suite
+(``tests/integration/foreign_keys/test_cascade_multi_class_apply.py``), gated by
+``requires_redis_functions``. Mirrors
+``test_cascade_sf_held_ref_fakeredis_fallback.py`` exactly, for a union target.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rapyer.result import CascadeResult
+from rapyer.types.foreign_key import ForeignKey
+from rapyer.types.redis_set import RedisSet
+from rapyer.types.relational import resolve_relational_targets
+from tests.models.cascade_types import (
+    CascadeUnionMemberA,
+    CascadeUnionMemberB,
+    CascadeUnionOwner,
+    CascadeUnionSetOwner,
+)
+
+TTL_SECONDS = 120
+
+# The multi-candidate union fixtures are deliberately NOT part of the shared
+# CASCADE_PLANNER_MODELS list in conftest.py -- that list is the pre-phase
+# single-target set guarded byte-identical by test_no_preexisting_single_target
+# _model_is_silently_expanded. Wire the union models onto the SAME fakeredis
+# client the conftest fixture set up, restoring them afterwards so no global
+# registry state leaks into other tests.
+_UNION_MODELS = [
+    CascadeUnionMemberA,
+    CascadeUnionMemberB,
+    CascadeUnionOwner,
+    CascadeUnionSetOwner,
+]
+_DECLARED_UNION_CASCADE_TTL = {
+    model: model.Meta.cascade_ttl for model in _UNION_MODELS
+}
+
+
+@pytest_asyncio.fixture
+async def setup_fake_redis_for_union_cascade_apply(
+    setup_fake_redis_for_cascade_apply,
+    fake_redis_client,
+):
+    """Extend the cascade-apply fakeredis wiring to the union fixtures used here,
+    onto the same fake client (scripts already registered by the base fixture)."""
+    originals = {}
+    for model in _UNION_MODELS:
+        originals[model] = (
+            model.Meta.redis,
+            model.Meta.is_fake_redis,
+            model.Meta.cascade_ttl,
+        )
+        model.Meta.redis = fake_redis_client
+        model.Meta.is_fake_redis = True
+        model.Meta.cascade_ttl = _DECLARED_UNION_CASCADE_TTL[model]
+    resolve_relational_targets(_UNION_MODELS)
+    yield
+    for model, (redis, is_fake, cascade_ttl) in originals.items():
+        model.Meta.redis = redis
+        model.Meta.is_fake_redis = is_fake
+        model.Meta.cascade_ttl = cascade_ttl
+
+
+@pytest.mark.asyncio
+async def test_scalar_union_owner_cascade_on_fakeredis_refreshes_own_main_key_not_member(
+    setup_fake_redis_for_union_cascade_apply,
+    fake_redis_client,
+):
+    # Arrange: a scalar union owner (inline Reference[A | B]) referencing a
+    # concrete member. The inline FK lives in the owner's OWN JSON document, so
+    # the owner has a main document key. On fakeredis the member is never reached
+    # (the Function never traverses), proving the documented no-op divergence:
+    # the root's OWN main key re-arms, the reached member does NOT.
+    member = await CascadeUnionMemberA(name="reached").asave()
+    owner = await CascadeUnionOwner(ref=member.key).asave()
+
+    await fake_redis_client.persist(owner.key)
+    await fake_redis_client.persist(member.key)
+
+    # Act
+    result = await owner.aset_ttl(TTL_SECONDS, cascade=True)
+
+    # Assert
+    # Zero-drift fast-path result: the native EXPIRE loop tallies nothing,
+    # including zero class drift (mismatched_class=0).
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
+    # Root's OWN main key refreshed ...
+    assert await fake_redis_client.ttl(owner.key) > 0
+    # ... reached union member NOT re-armed (no traversal on fakeredis).
+    assert await fake_redis_client.ttl(member.key) in (-1, -2)
+
+
+@pytest.mark.asyncio
+async def test_union_set_owner_cascade_on_fakeredis_refreshes_own_container_not_member(
+    setup_fake_redis_for_union_cascade_apply,
+    fake_redis_client,
+):
+    # Arrange: an SF-held union owner (RedisSet[Reference[A | B]]) holding one
+    # concrete union member. This exercises the OWN-CONTAINER leg of the fast
+    # path: on fakeredis the owner's own SET container key is re-armed via a plain
+    # EXPIRE, but the edge to the member is NEVER followed -- the Function that
+    # would resolve the member's {class}:{pk} prefix does not run here.
+    #
+    # NOTE: CascadeUnionSetOwner declares only the RedisSet special field (no
+    # scalar field), so its main JSON document is empty and no main document key
+    # is persisted on asave() -- the own-key refresh in the SF case is therefore
+    # proven on the CONTAINER key. The scalar-owner test above covers the own
+    # MAIN-key refresh leg.
+    member = await CascadeUnionMemberA(name="reached").asave()
+    owner = await CascadeUnionSetOwner().asave()
+    await owner.refs.aadd(ForeignKey(member.key))
+
+    refs_key = RedisSet.special_field_key(owner.key, "refs")
+    await fake_redis_client.persist(refs_key)
+    await fake_redis_client.persist(member.key)
+
+    # Act
+    result = await owner.aset_ttl(TTL_SECONDS, cascade=True)
+
+    # Assert
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
+    # Root's OWN container key refreshed ...
+    assert await fake_redis_client.ttl(refs_key) > 0
+    # ... reached union member NOT re-armed (documented no-op divergence).
+    assert await fake_redis_client.ttl(member.key) in (-1, -2)

--- a/tests/unit/cascade/test_cascade_plan_injection.py
+++ b/tests/unit/cascade/test_cascade_plan_injection.py
@@ -6,6 +6,7 @@ from rapyer.cascade.planner import (
     CascadeEdge,
     CascadePlanEntry,
     build_cascade_plan,
+    cascade_plan_hash,
     cascade_plan_json,
 )
 from rapyer.scripts.constants import ATOMIC_GET_OR_CREATE_SCRIPT_NAME
@@ -17,7 +18,7 @@ from rapyer.scripts.registry import (
 from tests.unit.cascade.conftest import CASCADE_PLANNER_MODELS
 
 
-def _edge(target: str) -> CascadeEdge:
+def _edge(target: str, candidates: list[str] | None = None) -> CascadeEdge:
     return CascadeEdge(
         path=f"$.{target.lower()}",
         target=target,
@@ -26,6 +27,7 @@ def _edge(target: str) -> CascadeEdge:
         refresh_target_ttl=True,
         refresh_target_special_keys=True,
         resets_depth_budget=False,
+        candidates=candidates,
     )
 
 
@@ -68,6 +70,31 @@ def test_cascade_plan_json_round_trips_full_plan_to_expected_shape():
     assert decoded["Foo"]["ttl"] == 10
     assert decoded["Foo"]["fks"][0]["target"] == "Author"
     assert decoded["Author"]["fks"] == []
+
+
+def test_single_target_plan_json_and_hash_are_byte_identical_golden():
+    # Arrange
+    # The load-bearing byte-identity invariant (CMCT-03/CMCT-09): after adding
+    # the sibling `candidates` field, a single-target plan must serialize
+    # character-for-character as before and keep the same plan hash — otherwise
+    # every Redis Function library/function name (which embeds the hash) churns.
+    plan = {"A": _entry("B"), "B": _entry()}
+
+    # Act
+    payload = cascade_plan_json(plan)
+
+    # Assert
+    expected = (
+        '{"A":{"ttl":10,"special_suffixes":[],"fks":[{"path":"$.b",'
+        '"target":"B","is_collection":false,"recurse_into_target":true,'
+        '"refresh_target_ttl":true,"refresh_target_special_keys":true,'
+        '"resets_depth_budget":false}]},"B":{"ttl":10,"special_suffixes":[],'
+        '"fks":[]}}'
+    )
+    assert payload == expected
+    assert cascade_plan_hash(payload) == "0bc1f0e973ecfcf4"
+    # candidates=None is dropped: a single-target edge carries no candidates key.
+    assert '"candidates"' not in payload
 
 
 def test_cascade_plan_json_serializes_every_class_in_the_plan():

--- a/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_fakeredis_fallback.py
@@ -32,7 +32,9 @@ async def test_set_ref_parent_cascade_on_fakeredis_refreshes_root_and_container_
     result = await parent.aset_ttl(TTL_SECONDS, cascade=True)
 
     # Assert
-    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
     assert await fake_redis_client.ttl(parent.key) > 0
     assert await fake_redis_client.ttl(refs_key) > 0
     assert await fake_redis_client.ttl(author.key) in (-1, -2)
@@ -57,7 +59,9 @@ async def test_pq_ref_parent_cascade_on_fakeredis_refreshes_root_and_container_n
     result = await parent.aset_ttl(TTL_SECONDS, cascade=True)
 
     # Assert
-    assert result == CascadeResult(dangling_children=0, dangling_special=0)
+    assert result == CascadeResult(
+        dangling_children=0, dangling_special=0, mismatched_class=0
+    )
     assert await fake_redis_client.ttl(parent.key) > 0
     assert await fake_redis_client.ttl(queue_key) > 0
     assert await fake_redis_client.ttl(author.key) in (-1, -2)

--- a/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
+++ b/tests/unit/cascade/test_cascade_sf_held_ref_plan.py
@@ -165,5 +165,7 @@ def test_plain_sf_container_is_not_an_fk_edge_but_needs_the_cascade_script():
 def test_nested_sf_held_ref_traversal_stays_deferred():
     # Nested SF-held refs are deferred: the SF branch fires only at top level.
     fks = []
-    _static_walk_fk_edges(CascadeSetRefParent, "$.holder", fks, top_level=False)
+    _static_walk_fk_edges(
+        CascadeSetRefParent, "$.holder", fks, [CascadeSetRefParent], top_level=False
+    )
     assert all(edge.sf_container is None for edge in fks)

--- a/tests/unit/cascade/test_cascade_ttl_required_validation.py
+++ b/tests/unit/cascade/test_cascade_ttl_required_validation.py
@@ -8,7 +8,7 @@ from rapyer.cascade.planner import (
 from rapyer.errors import CascadeTargetTtlMissingError
 
 
-def _plan(a_ttl, b_ttl, edge_target="B"):
+def _plan(a_ttl, b_ttl, edge_target="B", candidates=None):
     return {
         "A": CascadePlanEntry(
             ttl=a_ttl,
@@ -22,6 +22,7 @@ def _plan(a_ttl, b_ttl, edge_target="B"):
                     refresh_target_ttl=True,
                     refresh_target_special_keys=True,
                     resets_depth_budget=False,
+                    candidates=candidates,
                 )
             ],
         ),
@@ -43,6 +44,40 @@ def test_raises_when_cascade_reachable_target_has_no_ttl():
 
     # Assert
     assert exc_info.value.model_name == "B"
+
+
+def test_raises_on_a_non_first_candidate_that_lacks_ttl():
+    # Arrange
+    # A multi-candidate edge whose FIRST candidate is fine but whose SECOND
+    # candidate declares no Meta.ttl must still fail fast, naming the offending
+    # (non-first) candidate — the CMCT-06 per-candidate guarantee.
+    plan = {
+        "A": CascadePlanEntry(
+            ttl=30,
+            special_suffixes=[],
+            fks=[
+                CascadeEdge(
+                    path="$.ref",
+                    target="First",
+                    is_collection=False,
+                    recurse_into_target=True,
+                    refresh_target_ttl=True,
+                    refresh_target_special_keys=True,
+                    resets_depth_budget=False,
+                    candidates=["First", "Second"],
+                )
+            ],
+        ),
+        "First": CascadePlanEntry(ttl=60, special_suffixes=[], fks=[]),
+        "Second": CascadePlanEntry(ttl=None, special_suffixes=[], fks=[]),
+    }
+
+    # Act
+    with pytest.raises(CascadeTargetTtlMissingError) as exc_info:
+        validate_cascade_ttl_targets(plan)
+
+    # Assert
+    assert exc_info.value.model_name == "Second"
 
 
 def test_does_not_raise_when_target_ttl_is_set():


### PR DESCRIPTION
## Summary

Extends the TTL cascade so a single FK edge referencing a `Reference[A | B]` union or a polymorphic base class resolves to **multiple candidate target classes**.

- **Phase 1 (planner):** `_unwrap_relational_target` now enumerates every candidate (union members + registered subclasses); `CascadeEdge` carries a `candidates` list alongside `target`; single-target plan JSON stays **byte-identical** (golden hash unchanged); `validate_cascade_ttl_targets` fails fast for every candidate.
- **Phase 2 (traversal + guard + docs):** the server-side Lua `push_child` resolves each reached key's actual class from its `{class}:{pk}` first-colon prefix, exact-matches it against the edge's candidates, and re-arms each reached child to **its own** class's `Meta.ttl` / special-suffix keys / outgoing edges. Non-candidate reaches are tallied via a new third FCALL return element `mismatched_class`; corrupt/no-colon reaches are silent, uncounted dead-ends. Adds an init-time `CascadeKeyInitialsError` guard (a cascade participant's `class_key_initials()` must equal `__name__`) and docs.

Single-target cascade behavior is preserved byte-for-byte; the per-child cascading-TTL-refresh apply layer is reused unchanged.

## Testing

- **Unit + fakeredis:** 840 passed (102 cascade), byte-identity golden hash `0bc1f0e973ecfcf4` unchanged.
- **Real Redis Stack 7.4.7:** full multi-class integration matrix (12 tests — union across scalar/list/dict/set/priority-queue shapes, colon-bearing pk, mixed-class diamond, depth-budget truncation through a resolved-class edge, non-candidate drift tally, corrupt dead-end) plus the full integration suite: **1636 passed, 205 skipped, 0 failures**.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cascade TTL updates now support union and polymorphic references across scalar, collection, and special-field relationships.
  - Referenced records resolve to their concrete class, allowing each class’s TTL settings to be applied.
  - Cascade results now report class mismatches separately from dangling references.

- **Bug Fixes**
  - Invalid or malformed cascade targets are safely skipped without interrupting processing.
  - Initialization now detects incompatible cascade key configuration early.

- **Documentation**
  - Added guidance and runnable examples for multi-class cascade behavior, TTL requirements, and configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->